### PR TITLE
Different message on Windows after starting boot2docker VM

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -78,7 +78,9 @@ func cmdStart() int {
 
 	switch runtime.GOOS {
 	case "windows":
-		fmt.Println("Docker client does not run on Windows for now. Please SSH into the VM instead.")
+		logf("Docker client does not run on Windows for now. Please use")
+		logf("    %s ssh", os.Args[0])
+		logf("to SSH into the VM instead.")
 	default:
 		// Check if $DOCKER_HOST ENV var is properly configured.
 		if os.Getenv("DOCKER_HOST") != fmt.Sprintf("tcp://localhost:%d", B2D.DockerPort) {


### PR DESCRIPTION
Docker client does not run on Windows for now. People have to SSH into
the VM to work on Windows.
