### PR TITLE
Add verbose flag (-v) to show commands as they execute.  This helps tremendously in debugging.

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,17 +9,21 @@ import (
 
 // The following will be injected during the build process.
 var (
-	Version string
-	GitSHA  string
+	Version     string
+	GitSHA      string
+	verboseFlag = flag.Bool("v", false, "verbose flag to show commands as they execute.")
 )
 
-var usageShort = fmt.Sprintf(`Usage: %s {help|init|start|up|ssh|save|pause|stop|poweroff|reset|restart|status|info|delete|download|version} [<vm>]
+var usageShort = fmt.Sprintf(`Usage: %s [-v] {help|init|start|up|ssh|save|pause|stop|poweroff|reset|restart|status|info|delete|download|version} [<vm>]
 `, os.Args[0])
 
 // NOTE: the help message uses spaces, not tabs for indentation!
-var usageLong = fmt.Sprintf(`Usage: %s <command> [<vm>]
+var usageLong = fmt.Sprintf(`Usage: %s [-v] <command> [<vm>]
 
 boot2docker management utility.
+
+Flags:
+    -v              Verbose flag to show commands as they execute.
 
 Commands:
 
@@ -90,5 +94,6 @@ func run() int {
 }
 
 func main() {
+	flag.Parse()
 	os.Exit(run())
 }

--- a/vbm.go
+++ b/vbm.go
@@ -7,10 +7,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 // Convenient function to exec a command.
 func cmd(name string, args ...string) error {
+	if *verboseFlag {
+		logf("executing: %v %v", name, strings.Join(args, " "))
+	}
 	cmd := exec.Command(name, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
I have found the "-v" flag really helpful for debugging problems.
Please let me know if I'm not using the github tools properly, as some things seem really odd.
Thanks.
-- Glenn
