### PR TITLE
Fixes issue #48.

### DIFF
--- a/vbm.go
+++ b/vbm.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 )
 
 // Convenient function to exec a command.
@@ -79,11 +78,7 @@ func getHostOnlyNetworkInterface() (string, error) {
 			return "", err
 		}
 		ifname = string(groups[1])
-		op := "add"
-		if runtime.GOOS == "windows" {
-			op = "modify" // "add" fails on Windows, but "modify" works.
-		}
-		out, err = exec.Command(B2D.VBM, "dhcpserver", op,
+		out, err = exec.Command(B2D.VBM, "dhcpserver", "modify",
 			"--ifname", ifname,
 			"--ip", B2D.DHCPIP,
 			"--netmask", B2D.NetworkMask,


### PR DESCRIPTION
There were three problems with 'init' on Windows:
1) An existing hostonlyifs is never reused because the IP address listed with the "vboxmanage" command never matches the host IP address.
2) When creating an interface, the interface name has spaces and '#' in the name so the regexp for finding the name never matched the name that was returned.
3) "vboxmanage dhcpserver add" always failed, but "vboxmanage dhcpserver modify" works on Windows.

This PR solves #2 and #3, but #1 is still an issue.  Fortunately, solving #2 and #3 allows Windows to successfully initialize a new VM.  However, the ISO is now panicing on startup on Windows, but that is a totally separate issue.
