### PR TITLE
Test for cfg dir existance

### DIFF
--- a/config.go
+++ b/config.go
@@ -75,7 +75,7 @@ func getCfgDir(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(cwd, name), nil
+	return cwd, nil
 }
 
 // Read configuration from both profile and flags. Flags override profile.


### PR DESCRIPTION
When testing on win8.1 and win7 sp1, I found that the error is different, and tbh, it looks to me like we intended to only choose a dir _if_ it exists - so I've added the existance test

also - if we're falling back to a last hope (`cwd()`) then use that dir, don't 'hope' that there is a .boot2docker dir in it.
