### PR TITLE
Fixes util.go/cmd() so cmdSSH() works again

### DIFF
--- a/util.go
+++ b/util.go
@@ -124,5 +124,10 @@ func cmd(name string, args ...string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 	}
+	if name == B2D.SSH {
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 	return cmd.Run()
 }


### PR DESCRIPTION
Before this PR: 

```
|ruby-1.9.3-p448| Isaacs-MacBook-Air-2 in ~/git/yacn/boot2docker-cli
± |master ✗| → b2d status && echo && b2d version && echo && b2d ssh -v
running

Client version: v0.7.0-dev
Git commit: d88b216

2014/04/01 14:42:48 executing: VBoxManage showvminfo boot2docker-vm --machinereadable
2014/04/01 14:42:48 executing: ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2022 docker@localhost
Pseudo-terminal will not be allocated because stdin is not a terminal.
Warning: Permanently added '[localhost]:2022' (RSA) to the list of known hosts.
docker@localhost's password:
boot2docker: 0.7.1
2014/04/01 14:42:51 exit status 1
```

After:

```
|ruby-1.9.3-p448| Isaacs-MacBook-Air-2 in ~/git/yacn/boot2docker-cli
± |fix/broken-cmdSSH ✗| → b2d status && echo && b2d version && echo && b2d ssh -v
running

Client version: v0.7.0-dev
Git commit: 4603d47

2014/04/01 15:35:45 executing: VBoxManage showvminfo boot2docker-vm --machinereadable
2014/04/01 15:35:45 executing: ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2022 docker@localhost
Warning: Permanently added '[localhost]:2022' (RSA) to the list of known hosts.
docker@localhost's password:
                        ##        .
                  ## ## ##       ==
               ## ## ## ##      ===
           /""""""""""""""""\___/ ===
      ~~~ {~~ ~~~~ ~~~ ~~~~ ~~ ~ /  ===- ~~~
           \______ o          __/
             \    \        __/
              \____\______/
 _                 _   ____     _            _
| |__   ___   ___ | |_|___ \ __| | ___   ___| | _____ _ __
| '_ \ / _ \ / _ \| __| __) / _` |/ _ \ / __| |/ / _ \ '__|
| |_) | (_) | (_) | |_ / __/ (_| | (_) | (__|   <  __/ |
|_.__/ \___/ \___/ \__|_____\__,_|\___/ \___|_|\_\___|_|
boot2docker: 0.7.1
docker@boot2docker:~$ exit
Connection to localhost closed.
```
