### PR TITLE
Boot2docker config

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,26 +109,31 @@ to remove it completely.
 ## Configuration
 
 The `boot2docker-cli` binary reads configuration from `$BOOT2DOCKER_PROFILE`, or
-if not found, from `$BOOT2DOCKER_DIR/profile`. Currently you can configure
-the following options (undefined options take default values):
+if not found, from `$BOOT2DOCKER_DIR/profile`. `./boot2docker-cli config` will
+tell you where it is looking for the file, and will also output the settings that 
+are in use, so you can initialise a default file to customise using 
+`boot2docker-cli config > /home/sven/.boot2docker/profile`.
+
+Currently you can configure the following options (undefined options take 
+default values):
 
 ```ini
 # Comments must be on their own lines; inline comments are not supported.
 
 # path to VirtualBox management utility
-vbm=VBoxManage
+vbm="VBoxManage"
 
 # path to SSH client utility
-ssh=ssh
+ssh="ssh"
 
 # name of boot2docker virtual machine
-vm=boot2docker-vm
+vm="boot2docker-vm"
 
 # path to boot2docker config directory
-dir=$HOME/.boot2docker
+dir="$HOME/.boot2docker"
 
 # path to boot2docker ISO image
-iso=$BOOT2DOCKER_DIR/boot2docker.iso
+iso="$BOOT2DOCKER_DIR/boot2docker.iso"
 
 # VM disk image size in MB
 disksize=20000

--- a/cmds.go
+++ b/cmds.go
@@ -182,6 +182,19 @@ func cmdUp() int {
 	return 0
 }
 
+// Tell the user the config (and later let them set it?)
+func cmdConfig() int {
+	dir, err := getCfgDir(".boot2docker")
+	if err != nil {
+		logf("Error working out Profile file location: %s", err)
+		return 1
+	}
+	filename := getCfgFilename(dir)
+	logf("boot2docker profile filename: %s", filename)
+	fmt.Println(printConfig())
+	return 0
+}
+
 // Suspend and save the current state of VM on disk.
 func cmdSave() int {
 	m, err := vbx.GetMachine(B2D.VM)

--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ func run() int {
 	switch cmd := flags.Arg(0); cmd {
 	case "download":
 		return cmdDownload()
+	case "config", "cfg":
+		return cmdConfig()
 	case "init":
 		return cmdInit()
 	case "up", "start", "boot", "resume":


### PR DESCRIPTION
contains #91, please ignore the Makefile change..

I'm not 100% sure that the `$ENVVAR` expansion in an ini file makes sense long term - please, discuss?

My interest here was to make it easy to create a default profile file, and then as I was working on it I was talking to @crosbymichael, and he suggested I should look at using the toml library for parsing the profile file. I think I like it as a simplification of our marshaling code.. 
