### PR TITLE
remove the trailing <vm> parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,7 @@ lowerip=192.168.59.103
 upperip=192.168.59.254
 ```
 
-Environment variables of the form `$ENVVAR` in the profile will be expanded,
-even on Windows.
-
-You can override the configurations using command-line flags. Type
+You can override the configurations using matching command-line flags. Type
 `boot2docker-cli -h` for more information. The configuration file options are
 the same as the command-line flags with long names.
 

--- a/config.go
+++ b/config.go
@@ -157,11 +157,6 @@ func config() (*flag.FlagSet, error) {
 		return nil, err
 	}
 
-	// Name of VM is the second argument. Override the value set in flag.
-	if vm := flags.Arg(1); vm != "" {
-		B2D.VM = vm
-	}
-
 	vbx.Verbose = B2D.Verbose
 	vbx.VBM = B2D.VBM
 	return flags, nil
@@ -179,18 +174,18 @@ func usageLong(flags *flag.FlagSet) {
 boot2docker management utility.
 
 Commands:
-    init [<vm>]             Create a new boot2docker VM.
-    up|start|boot [<vm>]    Start VM from any states.
+    init                    Create a new boot2docker VM.
+    up|start|boot           Start VM from any states.
     ssh                     Login to VM via SSH.
-    save|suspend [<vm>]     Suspend VM and save state to disk.
-    down|stop|halt [<vm>]   Gracefully shutdown the VM.
-    restart [<vm>]          Gracefully reboot the VM.
-    poweroff [<vm>]         Forcefully power off the VM (might corrupt disk image).
-    reset [<vm>]            Forcefully power cycle the VM (might corrupt disk image).
-    delete [<vm>]           Delete boot2docker VM and its disk image.
+    save|suspend            Suspend VM and save state to disk.
+    down|stop|halt          Gracefully shutdown the VM.
+    restart                 Gracefully reboot the VM.
+    poweroff                Forcefully power off the VM (might corrupt disk image).
+    reset                   Forcefully power cycle the VM (might corrupt disk image).
+    delete                  Delete boot2docker VM and its disk image.
     config|cfg              Show selected profile file settings.
-    info [<vm>]             Display detailed information of VM.
-    status [<vm>]           Display current state of VM.
+    info                    Display detailed information of VM.
+    status                  Display current state of VM.
     download                Download boot2docker ISO image.
     version                 Display version information.
 


### PR DESCRIPTION
You can do the same thing with `--vm=`

```
$ ./boot2docker-cli-v0.8.0-linux-amd64 --vm=d2d status baz
running
$ ./boot2docker-cli-v0.8.0-linux-amd64 --vm=bar status d2d
2014/05/09 12:10:40 Failed to get machine "bar": machine does not exist
```
