### PR TITLE
Add ssh commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You need to have [Go compiler](http://golang.org) installed, and `$GOPATH`
 The binary will be available at `$GOPATH/bin/boot2docker-cli`. However the
 binary built this way will have missing version information when you run
 
-    boot2docker-cli version
+    $ boot2docker-cli version
 
 You can solve the issue by using `make goinstall`
 
@@ -80,7 +80,7 @@ Currently the binary cross-compiled from Windows/Linux to OS X has a [TLS
 issue](https://github.com/boot2docker/boot2docker-cli/issues/11), and as a
 result
 
-    boot2docker-cli download
+    $ boot2docker-cli download
 
 will fail. You need to do a native OS X build to avoid this problem.
 
@@ -89,22 +89,29 @@ will fail. You need to do a native OS X build to avoid this problem.
 
 To initialize a new boot2docker VM, run
 
-    boot2docker-cli init
+    $ boot2docker-cli init
 
 Then you can start the VM by
 
-    boot2docker-cli up
+    $ boot2docker-cli up
 
 To stop the VM, run
 
-    boot2docker-cli down
+    $ boot2docker-cli down
 
 And finally if you don't need the VM anymore, run
 
-    boot2docker-cli delete
+    $ boot2docker-cli delete
 
 to remove it completely.
 
+You can also run commands on the remote boot2docker virtual machine:
+
+    $ boot2docker-cli -m 123 ssh ip addr show eth1 |sed -ne 's/^[ \t]*inet[ \t]*\([0-9.]\+\)\/.*$/\1/p'
+    192.168.59.103
+
+In this case, the command tells you the host only interface IP address of the
+boot2docker vm, which you can then use to access ports you map from your containers.
 
 ## Configuration
 

--- a/cmds.go
+++ b/cmds.go
@@ -11,6 +11,7 @@ import (
 	//"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	vbx "github.com/boot2docker/boot2docker-cli/virtualbox"
@@ -377,12 +378,21 @@ func cmdSSH() int {
 		return 1
 	}
 
+	// find the ssh cmd string and then pass any remaining strings to ssh
+	// TODO: it's a shame to repeat the same code as in config.go, but I 
+	//       didn't find a way to share the unsharable without more rework
+	i := 1
+	for i < len(os.Args) && os.Args[i-1] != "ssh" {
+		i++
+	}
+
 	if err := cmd(B2D.SSH,
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-p", fmt.Sprintf("%d", B2D.SSHPort),
 		"-i", B2D.SSHKey,
 		"docker@localhost",
+		strings.Join(os.Args[i:], " "),
 	); err != nil {
 		logf("%s", err)
 		return 1

--- a/config.go
+++ b/config.go
@@ -152,8 +152,16 @@ func config() (*flag.FlagSet, error) {
 	if _, err := toml.DecodeFile(filename, &B2D); err != nil {
 		return nil, err
 	}
+
+	// for cmd==ssh only:
+	// only pass the params up to and including the `ssh` command - after that,
+	// there might be other -flags that are destined for the ssh cmd
+	i := 1
+	for i < len(os.Args) && os.Args[i-1] != "ssh" {
+		i++
+	}
 	// Command-line overrides profile config.
-	if err := flags.Parse(os.Args[1:]); err != nil {
+	if err := flags.Parse(os.Args[1:i]); err != nil {
 		return nil, err
 	}
 
@@ -176,7 +184,7 @@ boot2docker management utility.
 Commands:
     init                    Create a new boot2docker VM.
     up|start|boot           Start VM from any states.
-    ssh                     Login to VM via SSH.
+    ssh [ssh-command]       Login to VM via SSH.
     save|suspend            Suspend VM and save state to disk.
     down|stop|halt          Gracefully shutdown the VM.
     restart                 Gracefully reboot the VM.


### PR DESCRIPTION
includes #105

this will give us the ability to script configuration and orchestration of the vm

in my case, I want to auto-start a fresh boot2docker, and then kick start my home-vol container, samba share it and run up some of my dev env.
