### PR TITLE
Remove myself from the maintainers due to traveling

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,6 @@
 Steeve Morin <steeve.morin@gmail.com> (@steeve)
 Glenn Lewis <gmlewis@google.com> (@gmlewis)
 Michael Crosby <michael@crosbymichael.com> (@crosbymichael)
+# Riobard Zhan <me@riobard.com> (@riobard)  # inactive while traveling
 Sven Dowideit <sven.dowideit@docker.com> (@SvenDowideit)
 Tianon Gravi <admwiggin@gmail.com> (@tianon)


### PR DESCRIPTION
I'll be traveling out of country for a few weeks. Removing myself from the maintainers list so as to not block the LGTM process. 
