### PR TITLE
simplify the cfg path to BOOT2DOCKER_DIR, $HOME/.boot2docker and $USERPROFILE/.boot2docker

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -416,5 +416,6 @@ func cmdDownload() int {
 		logf("Failed to download ISO image: %s", err)
 		return 1
 	}
+	logf("Success: downloaded %s\n\tto %s", url, B2D.ISO)
 	return 0
 }


### PR DESCRIPTION
and create the .boot2docker dir if needed.

remove --dir= option for now, it would require double reading the flags and profile - might add it as a feature later, if its needed its side effects are somewhat complicated.
