### PR TITLE
change from using port 4243 to 2375 - this is incompatible with previous Boot2Docker ISO's

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ login via SSH.
 On Windows, [MSYS SSH](http://www.mingw.org/) provides a first class way to
 connect to the boot2docker VM using `boot2docker.exe ssh`.
 
+> **Note:** Docker now has an [IANA registered IP Port: 2375]( http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=docker)
+> , so the use of port 4243 is deprecated. This also means that new Boot2Docker
+> ISO releases and management tool are not compatible.
 
 ## Installation
 
@@ -142,8 +145,8 @@ Memory = 1024
 # host port forwarding to port 22 in the VM
 SSHPort = 2022
 
-# host port forwarding to port 4243 in the VM
-DockerPort = 4243
+# host port forwarding to port 2375 in the VM
+DockerPort = 2375
 
 # host-only network host IP
 HostIP = "192.168.59.3"

--- a/cmds.go
+++ b/cmds.go
@@ -106,7 +106,7 @@ func cmdInit() int {
 
 	pfRules := map[string]vbx.PFRule{
 		"ssh":    vbx.PFRule{Proto: vbx.PFTCP, HostIP: net.ParseIP("127.0.0.1"), HostPort: B2D.SSHPort, GuestPort: 22},
-		"docker": vbx.PFRule{Proto: vbx.PFTCP, HostIP: net.ParseIP("127.0.0.1"), HostPort: B2D.DockerPort, GuestPort: 4243},
+		"docker": vbx.PFRule{Proto: vbx.PFTCP, HostIP: net.ParseIP("127.0.0.1"), HostPort: B2D.DockerPort, GuestPort: 2375},
 	}
 
 	for name, rule := range pfRules {

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var B2D struct {
 
 	// NAT network: port forwarding
 	SSHPort    uint16 // host SSH port (forward to port 22 in VM)
-	DockerPort uint16 // host Docker port (forward to port 4243 in VM)
+	DockerPort uint16 // host Docker port (forward to port 2375 in VM)
 
 	// host-only network
 	HostIP      net.IP
@@ -124,7 +124,7 @@ func config() (*flag.FlagSet, error) {
 	flags.UintVarP(&B2D.DiskSize, "disksize", "s", 20000, "boot2docker disk image size (in MB).")
 	flags.UintVarP(&B2D.Memory, "memory", "m", 1024, "virtual machine memory size (in MB).")
 	flags.Uint16Var(&B2D.SSHPort, "sshport", 2022, "host SSH port (forward to port 22 in VM).")
-	flags.Uint16Var(&B2D.DockerPort, "dockerport", 4243, "host Docker port (forward to port 4243 in VM).")
+	flags.Uint16Var(&B2D.DockerPort, "dockerport", 2375, "host Docker port (forward to port 2375 in VM).")
 	flags.IPVar(&B2D.HostIP, "hostip", net.ParseIP("192.168.59.3"), "VirtualBox host-only network IP address.")
 	flags.IPMaskVar(&B2D.NetMask, "netmask", flag.ParseIPv4Mask("255.255.255.0"), "VirtualBox host-only network mask.")
 	flags.BoolVar(&B2D.DHCPEnabled, "dhcp", true, "enable VirtualBox host-only network DHCP.")

--- a/release.sh
+++ b/release.sh
@@ -8,7 +8,7 @@ set -e
 TMP=$(mktemp -d /tmp/b2d-cli.XXXXXX)
 echo Building in $TMP
 export GOPATH=$TMP
-export DOCKER_HOST=tcp://localhost:4243
+export DOCKER_HOST=tcp://localhost:2375
 go get github.com/boot2docker/boot2docker-cli
 cd ${TMP}/src/github.com/boot2docker/boot2docker-cli
 

--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -236,7 +236,7 @@ func GetMachine(id string) (*Machine, error) {
 			m.CfgFile = val
 			m.BaseFolder = filepath.Dir(val)
 		case "Forwarding(0)":
-			// Forwarding(0)="docker,tcp,127.0.0.1,5555,,4243"
+			// Forwarding(0)="docker,tcp,127.0.0.1,5555,,"
 			vals := strings.Split(val, ",")
 			n, err := strconv.ParseUint(vals[3], 10, 32)
 			if err != nil {


### PR DESCRIPTION
While I could wire up both ports on the VM, we would then need 2 ports on the osx box, add cfg and so on, all of which we don't want.

I'll contemplate making b2d-cli ssh to the container to get the /etc/version file and fall back, but more testing will, er, suck.
