### PR TITLE
allows me to do $(boot2docker ip)

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -452,9 +452,7 @@ func cmdIP() int {
 		vals := strings.Split(strings.TrimSpace(line), " ")
 		if vals[0] == "inet" {
 			ip := vals[1][:strings.Index(vals[1], "/")]
-			errf("\nThe VM's Host only interface IP address is: ")
 			fmt.Printf("%s", ip)
-			errf("\n\n")
 			return 0
 		}
 	}


### PR DESCRIPTION
```
boot2docker ip

The VM's Host only interface IP address is: 192.168.59.104
```

to ...

```
boot2docker ip
192.168.59.104
```
