### PR TITLE
Deprecate support for --dockerport flag.

### DIFF
--- a/config.go
+++ b/config.go
@@ -134,7 +134,7 @@ func config() (*flag.FlagSet, error) {
 	flags.UintVarP(&B2D.DiskSize, "disksize", "s", 20000, "boot2docker disk image size (in MB).")
 	flags.UintVarP(&B2D.Memory, "memory", "m", 2048, "virtual machine memory size (in MB).")
 	flags.Uint16Var(&B2D.SSHPort, "sshport", 2022, "host SSH port (forward to port 22 in VM).")
-	flags.Uint16Var(&B2D.DockerPort, "dockerport", 2375, "host Docker port (forward to port 2375 in VM).")
+	flags.Uint16Var(&B2D.DockerPort, "dockerport", 0, "host Docker port (forward to port 2375 in VM). (deprecated - use with care)")
 	flags.IPVar(&B2D.HostIP, "hostip", net.ParseIP("192.168.59.3"), "VirtualBox host-only network IP address.")
 	flags.IPMaskVar(&B2D.NetMask, "netmask", flag.ParseIPv4Mask("255.255.255.0"), "VirtualBox host-only network mask.")
 	flags.BoolVar(&B2D.DHCPEnabled, "dhcp", true, "enable VirtualBox host-only network DHCP.")


### PR DESCRIPTION
As the result of long standing issues with support for half-close of inbound
TCP connections to Virtual Box guests on (at least) OSX use of port-forwarded
docker connections should be discouraged.

So, if the user really wants to configure it, let them. Otherwise, don't
set it up in the first place.

See boot2docker issue #150 (and others) for details.

Docker-DCO-1.1-Signed-off-by: Jon Seymour jon.seymour@gmail.com (github: jonseymour)
