### PR TITLE
Add "quiet" option and its effect on `ip` subcommand

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -479,9 +479,13 @@ func cmdIP() int {
 		IP = RequestIPFromSSH(m)
 	}
 	if IP != "" {
-		errf("\nThe VM's Host only interface IP address is: ")
+		if !B2D.Quiet {
+			errf("\nThe VM's Host only interface IP address is: ")
+		}
 		fmt.Printf("%s", IP)
-		errf("\n\n")
+		if !B2D.Quiet {
+			errf("\n\n")
+		}
 	} else {
 		errf("\nFailed to get VM Host only IP address.\n")
 		errf("\tWas the VM initilized using boot2docker?\n")

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ var B2D struct {
 	// indentation all the time.
 
 	// Gereral flags.
+	Quiet   bool
 	Verbose bool
 	VBM     string
 
@@ -138,6 +139,7 @@ func config() (*flag.FlagSet, error) {
 	flags.IPVar(&B2D.HostIP, "hostip", net.ParseIP("192.168.59.3"), "VirtualBox host-only network IP address.")
 	flags.IPMaskVar(&B2D.NetMask, "netmask", flag.ParseIPv4Mask("255.255.255.0"), "VirtualBox host-only network mask.")
 	flags.BoolVar(&B2D.DHCPEnabled, "dhcp", true, "enable VirtualBox host-only network DHCP.")
+	flags.BoolVarP(&B2D.Quiet, "quiet", "q", false, "run the command in quiet mode")
 	flags.IPVar(&B2D.DHCPIP, "dhcpip", net.ParseIP("192.168.59.99"), "VirtualBox host-only network DHCP server address.")
 	flags.IPVar(&B2D.LowerIP, "lowerip", net.ParseIP("192.168.59.103"), "VirtualBox host-only network DHCP lower bound.")
 	flags.IPVar(&B2D.UpperIP, "upperip", net.ParseIP("192.168.59.254"), "VirtualBox host-only network DHCP upper bound.")


### PR DESCRIPTION
I was dissatisfied with current output of `boot2docker ip` as I find the explanatory text a little un-UNIX-ey.  However I realize it is important for usability.  This PR adds `-q` / `--quiet` option so that it will just spit out the IP and nothing else, this enhances scriptability and usage in case like:

``` sh
curl $(boot2docker ip -q):5000/users/sven
```
