### PR TITLE
Fix SSH oddness by passing arguments directly through to SSH as-is

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -437,15 +437,16 @@ func cmdSSH() int {
 		i++
 	}
 
-	if err := cmdInteractive(B2D.SSH,
-		//"-vvv", //TODO: add if its boot2docker -v
+	sshArgs := append([]string{
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "LogLevel=quiet", // suppress "Warning: Permanently added '[localhost]:2022' (ECDSA) to the list of known hosts."
 		"-p", fmt.Sprintf("%d", m.SSHPort),
 		"-i", B2D.SSHKey,
 		"docker@localhost",
-		strings.Join(os.Args[i:], " "),
-	); err != nil {
+	}, os.Args[i:]...)
+
+	if err := cmdInteractive(B2D.SSH, sshArgs...); err != nil {
 		logf("%s", err)
 		return 1
 	}


### PR DESCRIPTION
Also, added "LogLevel=quiet" to suppress the fun warning that was printed every time we run "boot2docker ssh ...".

Fixes #165
Closes #135 (since we can now do `boot2docker ssh -v ...` and it works as you'd expect, which is useful separately from `boot2docker -v ssh ...` which prints the exact command it's running)
