### PR TITLE
boot2docker #357 use natdnshostresolver1 for DNS on VPN

### DIFF
--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -332,6 +332,7 @@ func (m *Machine) Modify() error {
 		"--firmware", "bios",
 		"--bioslogofadein", "off",
 		"--bioslogofadeout", "off",
+		"--natdnshostresolver1", "on",
 		"--bioslogodisplaytime", "0",
 		"--biosbootmenu", "disabled",
 


### PR DESCRIPTION
OSX DNS is complicated, particularly if you have a VPN configured.  This setting creates a DNS proxy that uses OSX's resolver.  Part of the resolution for issue #357 in boot2docker
