### PR TITLE
Add download.sh file

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Set version to latest unless set by user
 if [ -z "$VERSION" ]; then
   VERSION="1.0.1"


### PR DESCRIPTION
Relates to https://github.com/boot2docker/boot2docker-cli/issues/174.

This is my first draft to provide a way to install boot2docker via a script. As mentioned in the issue, this can be invoked like this:

```
bash -c "`curl -sL https://raw.githubusercontent.com/boo2docker/boo2docker-cli/master/download.sh`" && sudo mv boot2docker /usr/local/bin/boot2docker
```

Some caveats:
- I don't have a Windows system around, so not sure if it works on Windows. From what I understand, it should work under Cygwin.
- You might want to change `release.sh` so that it updates the version in the `download.sh` file.

Closes #174
