### PR TITLE
Aliased destroy to delete to make it feel at home for vagrant devs

### DIFF
--- a/config.go
+++ b/config.go
@@ -190,7 +190,7 @@ func config() (*flag.FlagSet, error) {
 }
 
 func usageShort() {
-	errf("Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|delete|download|version} [<args>]\n", os.Args[0])
+	errf("Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|delete|destroy|download|version} [<args>]\n", os.Args[0])
 
 }
 
@@ -209,7 +209,7 @@ Commands:
     restart                 Gracefully reboot the VM.
     poweroff                Forcefully power off the VM (might corrupt disk image).
     reset                   Forcefully power cycle the VM (might corrupt disk image).
-    delete                  Delete boot2docker VM and its disk image.
+    delete|destroy          Delete boot2docker VM and its disk image.
     config|cfg              Show selected profile file settings.
     info                    Display detailed information of VM.
     ip                      Display the IP address of the VM's Host-only network.

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func run() int {
 		return cmdRestart()
 	case "reset":
 		return cmdReset()
-	case "delete":
+	case "delete", "destroy":
 		return cmdDelete()
 	case "info":
 		return cmdInfo()


### PR DESCRIPTION
A simple alias making it feel more at home for vagrant developers (`vagrant destroy`)
