### PR TITLE
Add Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: go
+
+# this should be exactly the same as what's in the Dockerfile
+go: 1.3
+
+# let us have pretty experimental Docker-based Travis workers
+sudo: false
+
+env:
+    - _GOOS=linux _GOARCH=amd64
+    - _GOOS=darwin _GOARCH=amd64
+    - _GOOS=windows _GOARCH=amd64
+
+install:
+    - env | sort
+    - gvm cross "$_GOOS" "$_GOARCH"
+    - export GOOS="$_GOOS" GOARCH="$_GOARCH"
+    - go env
+    - go get -d -v ./...
+
+script:
+    # TODO - some gofmt magic
+    - go build -v ./...
+    # TODO - go test -v ./... # (we first need to skip all the meaty vbox tests when "VBoxManage" isn't available, or mock it)

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ the same as the command-line flags with long names.
 
 ## Contribution
 
+[![Build Status](https://travis-ci.org/boot2docker/boot2docker-cli.svg?branch=master)](https://travis-ci.org/boot2docker/boot2docker-cli)
+
 We are implementing the same process as [Docker merge
 approval](https://github.com/dotcloud/docker/blob/master/CONTRIBUTING.md#merge-approval),
 so all commits need to be done via pull requests, and will need three or more


### PR DESCRIPTION
This is pretty basic, but it's a good start IMO.  As-is, it'll test whether we still successfully compile for the three platform+arch combinations we officially support, and we can grow it from there.

The `sudo: false` bit might not work immediately after enabling Travis for the boot2docker-cli repo (which can be enabled by a repo administrator at https://travis-ci.org/profile/boot2docker), but it might/should work soon (I've requested that the boot2docker org be added to the beta testers list for that).
