### PR TITLE
Upgrade the image - preserving machine state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ nbproject
 *.sublime-project
 *.sublime-workspace
 *.swp
+boot2docker-cli

--- a/cmds.go
+++ b/cmds.go
@@ -350,6 +350,20 @@ func cmdPoweroff() int {
 	return 0
 }
 
+// Upgrade the boot2docker iso - preserving server state
+func cmdUpgrade() int {
+	m, err := vbx.GetMachine(B2D.VM)
+	if err == nil && m.State == vbx.Running {
+		if cmdDownload() == 0 && cmdStop() == 0 {
+			return cmdUp()
+		} else {
+			return 0
+		}
+	} else {
+		return cmdDownload()
+	}
+}
+
 // Gracefully stop and then start the VM.
 func cmdRestart() int {
 	m, err := vbx.GetMachine(B2D.VM)

--- a/config.go
+++ b/config.go
@@ -190,8 +190,7 @@ func config() (*flag.FlagSet, error) {
 }
 
 func usageShort() {
-	errf("Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|delete|destroy|download|version} [<args>]\n", os.Args[0])
-
+	errf("Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|delete|destroy|download|upgrade|version} [<args>]\n", os.Args[0])
 }
 
 func usageLong(flags *flag.FlagSet) {
@@ -215,6 +214,7 @@ Commands:
     ip                      Display the IP address of the VM's Host-only network.
     status                  Display current state of VM.
     download                Download boot2docker ISO image.
+    upgrade                 Upgrade the boot2docker ISO image (if vm is running it will be stopped and started).    
     version                 Display version information.
 
 Options:

--- a/main.go
+++ b/main.go
@@ -55,6 +55,8 @@ func run() int {
 		return cmdSSH()
 	case "ip":
 		return cmdIP()
+	case "upgrade":
+		return cmdUpgrade()
 	case "version":
 		outf("Client version: %s\nGit commit: %s\n", Version, GitSHA)
 		return 0


### PR DESCRIPTION
Stop the VM, download, and restart (preserve machine state - ie if it was running before, it will be running after upgraded).

Docker-DCO-1.1-Signed-off-by: Michael Neale michael.neale@gmail.com (github: michaelneale)
