### PR TITLE
Revert "Sorry, I didn't test the effects of merging 2 PRs"

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -155,8 +155,8 @@ func cmdPoweroff() int {
 
 // Upgrade the boot2docker iso - preserving server state
 func cmdUpgrade() int {
-	m, err := driver.GetMachine(&B2D)
-	if err == nil && m.GetState() == driver.Running {
+	m, err := vbx.GetMachine(B2D.VM)
+	if err == nil && m.State == vbx.Running {
 		if cmdDownload() == 0 && cmdStop() == 0 {
 			return cmdUp()
 		} else {


### PR DESCRIPTION
Reverts boot2docker/boot2docker-cli#196

I'm backing out the driver refactor master for 1.1.2 - see https://github.com/boot2docker/boot2docker-cli/tree/new-driver-model
