### PR TITLE
Exit on virtualbox initialization error

### DIFF
--- a/dummy/machine.go
+++ b/dummy/machine.go
@@ -2,12 +2,16 @@ package dummy
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/boot2docker/boot2docker-cli/driver"
 )
 
 func init() {
-	driver.Register("dummy", InitFunc)
+	if err := driver.Register("dummy", InitFunc); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialize driver. Error : %s", err.Error())
+		os.Exit(1)
+	}
 }
 
 // Initialize the Machine.

--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -40,7 +40,7 @@ const (
 
 func init() {
 	if err := driver.Register("virtualbox", InitFunc); err != nil {
-		fmt.Printf("Failed to initialize driver. Error : %s", err.Error())
+		fmt.Fprintf(os.Stderr, "Failed to initialize driver. Error : %s", err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Just a minor fix to insure that the program does not continue if the call to `driver.Register` returns a non-nil error.
