### PR TITLE
Remove the errf and outf utility functions in favor of calling fmt functions

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -304,12 +304,12 @@ func cmdIP() int {
 		IP = RequestIPFromSSH(m)
 	}
 	if IP != "" {
-		errf("\nThe VM's Host only interface IP address is: ")
+		fmt.Fprintf(os.Stderr, "\nThe VM's Host only interface IP address is: ")
 		fmt.Printf("%s", IP)
-		errf("\n\n")
+		fmt.Fprintf(os.Stderr, "\n\n")
 	} else {
-		errf("\nFailed to get VM Host only IP address.\n")
-		errf("\tWas the VM initilized using boot2docker?\n")
+		fmt.Fprintf(os.Stderr, "\nFailed to get VM Host only IP address.\n")
+		fmt.Fprintf(os.Stderr, "\tWas the VM initilized using boot2docker?\n")
 	}
 	return 0
 }

--- a/config.go
+++ b/config.go
@@ -153,12 +153,12 @@ func config() (*flag.FlagSet, error) {
 }
 
 func usageShort() {
-	errf("Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|delete|destroy|download|version} [<args>]\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|delete|destroy|download|version} [<args>]\n", os.Args[0])
 }
 
 func usageLong(flags *flag.FlagSet) {
 	// NOTE: the help message uses spaces, not tabs for indentation!
-	errf(`Usage: %s [<options>] <command> [<args>]
+	fmt.Fprintf(os.Stderr, `Usage: %s [<options>] <command> [<args>]
 
 boot2docker management utility.
 
@@ -177,7 +177,7 @@ Commands:
     ip                      Display the IP address of the VM's Host-only network.
     status                  Display current state of VM.
     download                Download boot2docker ISO image.
-    upgrade                 Upgrade the boot2docker ISO image (if vm is running it will be stopped and started).    
+    upgrade                 Upgrade the boot2docker ISO image (if vm is running it will be stopped and started).
     version                 Display version information.
 
 Options:

--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "os"
+import (
+	"os"
+	"fmt"
+)
 
 // The following vars will be injected during the build process.
 var (
@@ -22,7 +25,7 @@ func main() {
 func run() int {
 	flags, err := config()
 	if err != nil {
-		errf("config error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "config error: %v\n", err)
 		return 1
 	}
 
@@ -58,7 +61,7 @@ func run() int {
 	case "upgrade":
 		return cmdUpgrade()
 	case "version":
-		outf("Client version: %s\nGit commit: %s\n", Version, GitSHA)
+		fmt.Printf("Client version: %s\nGit commit: %s\n", Version, GitSHA)
 		return 0
 	case "help":
 		flags.Usage()
@@ -67,7 +70,7 @@ func run() int {
 		usageShort()
 		return 0
 	default:
-		errf("Unknown command %q\n", cmd)
+		fmt.Fprintf(os.Stderr, "Unknown command %q\n", cmd)
 		usageShort()
 		return 1
 	}

--- a/util.go
+++ b/util.go
@@ -15,16 +15,6 @@ import (
 	"time"
 )
 
-// fmt.Printf to stdout. Convention is to outf info intended for scripting.
-func outf(f string, v ...interface{}) {
-	fmt.Printf(f, v...)
-}
-
-// fmt.Printf to stderr. Convention is to errf info intended for human.
-func errf(f string, v ...interface{}) {
-	fmt.Fprintf(os.Stderr, f, v...)
-}
-
 // Verbose output for debugging.
 func logf(fmt string, v ...interface{}) {
 	log.Printf(fmt, v...)


### PR DESCRIPTION
The use of outf and errf, simple wrappers over fmt.Printf and fmt.Fprintf(os.Stderr, ...) respectively, are completely unnecessary. The use of these functions lead only to non-idiomatic code and unnecessary obfuscation.
