### PR TITLE
Add b2d shellinit cmd

### DIFF
--- a/config.go
+++ b/config.go
@@ -175,7 +175,7 @@ func config() (*flag.FlagSet, error) {
 }
 
 func usageShort() {
-	fmt.Fprintf(os.Stderr, "Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|socket|delete|destroy|download|version} [<args>]\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|socket|shellinit|delete|destroy|download|version} [<args>]\n", os.Args[0])
 }
 
 func usageLong(flags *flag.FlagSet) {
@@ -198,6 +198,7 @@ Commands:
     info                    Display detailed information of VM.
     ip                      Display the IP address of the VM's Host-only network.
     socket                  Display the DOCKER_HOST socket to connect to.
+    shellinit               Display the Environment export shell command needed to set up the Docker client.
     status                  Display current state of VM.
     download                Download boot2docker ISO image.
     upgrade                 Upgrade the boot2docker ISO image (if vm is running it will be stopped and started).

--- a/main.go
+++ b/main.go
@@ -67,6 +67,8 @@ func run() error {
 		return cmdInfo()
 	case "socket":
 		return cmdSocket()
+	case "shellinit":
+		return cmdShellInit()
 	case "status":
 		return cmdStatus()
 	case "ssh":

--- a/util.go
+++ b/util.go
@@ -297,6 +297,11 @@ func RequestIPFromSerialPort(socket string) string {
 }
 
 // TODO: need to add or abstract to get a Serial coms version
+// RequestCertsUsingSSH requests certs using SSH. 
+// The assumption is that if the certs are in b2d:/home/docker/.docker
+// then the daemon is using TLS. We can't assume that because there are
+// certs in the local host's user dir, that the server is using them, so
+// for now, make sure things are updated from the server. (for `docker shellinit`)
 func RequestCertsUsingSSH(m driver.Machine) (string, error) {
 	cmd := getSSHCommand(m, "tar c /home/docker/.docker/*.pem")
 


### PR DESCRIPTION
ignore the first commit, its from #224

make setting up the DOCKER_HOST, and optionally DOCKER_CERT_PATH as easy as '$(boot2docker shellinit)'

this will be used by the osx and windows start scripts to magically set the right env.
