### PR TITLE
virtualbox has a 32 cpu hard limit

### DIFF
--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -393,11 +393,10 @@ func CreateMachine(mc *driver.MachineConfig) (*Machine, error) {
 	// Configure VM for Boot2docker
 	SetExtra(mc.VM, "VBoxInternal/CPUM/EnableHVP", "1")
 	m.OSType = "Linux26_64"
-	cpus := uint(runtime.NumCPU())
-	if cpus > 32 {
-		cpus = 32
+	m.CPUs = uint(runtime.NumCPU())
+	if m.CPUs > 32 {
+		m.CPUs = 32
 	}
-	m.CPUs = cpus
 	m.Memory = mc.Memory
 	m.SerialFile = mc.SerialFile
 


### PR DESCRIPTION
virtualbox has a 32 cpu hard limit, this sets it to that if runtime.NumCPU() exceeds this limit.
