### PR TITLE
Lets upgrade all running, saved and paused vm's and restart them, and al...

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -244,16 +244,18 @@ func cmdPoweroff() error {
 // Upgrade the boot2docker ISO - preserving server state
 func cmdUpgrade() error {
 	m, err := driver.GetMachine(&B2D)
-	if err == nil && m.GetState() == driver.Running {
-		// Windows won't let us move the ISO aside while it's in use
-		if cmdStop() == nil && cmdDownload() == nil {
-			return cmdUp()
-		} else {
-			return nil
+	if err == nil {
+		if m.GetState() == driver.Running || m.GetState() == driver.Saved || m.GetState() == driver.Paused {
+			// Windows won't let us move the ISO aside while it's in use
+			if err = cmdStop(); err == nil {
+				if err = cmdDownload(); err == nil {
+					err = cmdUp()
+				}
+			}
+			return err
 		}
-	} else {
-		return cmdDownload()
 	}
+	return cmdDownload()
 }
 
 // Gracefully stop and then start the VM.


### PR DESCRIPTION
...so tell the user if there was an error.

also for https://github.com/boot2docker/osx-installer/issues/63
