### PR TITLE
Use VERSION instead of hardcoding 1.1.2

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -4,7 +4,7 @@ set -e
 
 # Set version to latest unless set by user
 if [ -z "$VERSION" ]; then
-  VERSION="1.1.2"
+  VERSION=$(<VERSION)
 fi
 EXTENSION=""
 


### PR DESCRIPTION
`download.sh` is currently downloading an older version (1.1.2) of the releases. I think this is not the intended behaviour. The pull request uses the information from VERSION file instead.
