### PR TITLE
golang container lacks make.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Dockerfile to cross compile boot2docker-cli
 
 FROM golang:1.3-cross
+RUN apt-get update && apt-get install -y make
 
 ADD . /go/src/github.com/boot2docker/boot2docker-cli
 WORKDIR /go/src/github.com/boot2docker/boot2docker-cli


### PR DESCRIPTION
Followed instructions and cloned boot2docker-cli repo and ran `make`. The `boot2docker-cli-build` container builds fine but `make` is missing in that container.  This change adds that.
