### PR TITLE
Add configuration flag allowing the use of a custom b2d ISO source URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ SSHKey = "/Users/sven/.ssh/id_boot2docker"
 # name of boot2docker virtual machine
 VM = "boot2docker-vm"
 
+# URL pointing either to a Github "/releases" API endpoint to automatically
+# retrieve the `boot2docker.iso` asset from the latest released version of a
+# repo, or directly to an ISO image
+ISOURL = "https://api.github.com/repos/boot2docker/boot2docker/releases"
+#ISOURL = "https://github.com/boot2docker/boot2docker/releases/download/v1.0.0/boot2docker.iso"
+#ISOURL = "https://internal.corp.org/b2d.iso"
+
 # path to boot2docker ISO image
 ISO = "/Users/sven/.boot2docker/boot2docker.iso"
 

--- a/config.go
+++ b/config.go
@@ -91,6 +91,7 @@ func config() (*flag.FlagSet, error) {
 	// removed for now, requires re-parsing a new config file which is too messy
 	//flags.StringVarP(&B2D.Dir, "dir", "d", dir, "boot2docker config directory.")
 	B2D.Dir = dir
+	flags.StringVar(&B2D.ISOURL, "iso-url", "https://api.github.com/repos/boot2docker/boot2docker/releases", "source URL to provision the boot2docker ISO image.")
 	flags.StringVar(&B2D.ISO, "iso", filepath.Join(dir, "boot2docker.iso"), "path to boot2docker ISO image.")
 
 	// Sven disabled this, as it is broken - if I user with a fresh computer downloads

--- a/driver/config.go
+++ b/driver/config.go
@@ -19,6 +19,7 @@ type MachineConfig struct {
 	SSHKey   string // SSH key to send to the vm
 	VM       string // virtual machine name
 	Dir      string // boot2docker directory
+	ISOURL   string // Source URL to retrieve the ISO from
 	ISO      string // boot2docker ISO image path
 	DiskSize uint   // VM disk image size (MB)
 	Memory   uint   // VM memory size (MB)


### PR DESCRIPTION
Until now we have been using a heavily patched fork of the now-retired bash-based boot2docker script, but all we need on the script-side (apart from the ability to use a custom ISO) is now in the go port, so I'd like to move on and benefit from the all-in-one DMG installer on OS X.

I think there will always be a need for custom ISOs. We am using one currently in order to a company proxy for the docker engine and auto-create a larger swap partition at the first boot. These are of course things that could be made configurable, but is it really worth it? There will be always specific/exotic needs adding up over time, so this allows advanced users to do their own thing.
