### PR TITLE
Only create 4 ports on storage controller

### DIFF
--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -506,7 +506,7 @@ func CreateMachine(mc *driver.MachineConfig) (*Machine, error) {
 	}
 
 	// Set VM storage
-	if err := m.AddStorageCtl("SATA", driver.StorageController{SysBus: driver.SysBusSATA, HostIOCache: true, Bootable: true}); err != nil {
+	if err := m.AddStorageCtl("SATA", driver.StorageController{SysBus: driver.SysBusSATA, HostIOCache: true, Bootable: true, Ports: 4}); err != nil {
 		return m, err
 	}
 


### PR DESCRIPTION
As noted in this comment:

https://github.com/boot2docker/boot2docker-cli/commit/9935fda0d9ad944f8f5cabba23c21655a65cd298#commitcomment-8148801

This speeds up boot by ~10 seconds.

Signed-off-by: Ben Firshman ben@firshman.co.uk
