### PR TITLE
Deal with cert generation taking too long, re...

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -82,17 +82,17 @@ func cmdUp() error {
 
 	fmt.Println("Waiting for VM and Docker daemon to start...")
 	//give the VM a little time to start, so we don't kill the Serial Pipe/Socket
-	time.Sleep(600 * time.Millisecond)
+	time.Sleep(time.Duration(B2D.Waittime) * time.Millisecond)
 	natSSH := fmt.Sprintf("localhost:%d", m.GetSSHPort())
 	IP := ""
-	for i := 1; i < 30; i++ {
+	for i := 1; i < B2D.Retries; i++ {
 		print(".")
 		if B2D.Serial && runtime.GOOS != "windows" {
 			if IP, err = RequestIPFromSerialPort(m.GetSerialFile()); err == nil {
 				break
 			}
 		}
-		if err := read(natSSH, 1, 300*time.Millisecond); err == nil {
+		if err := read(natSSH, 1, time.Duration(B2D.Waittime)*time.Millisecond); err == nil {
 			if IP, err = RequestIPFromSSH(m); err == nil {
 				break
 			}
@@ -103,10 +103,10 @@ func cmdUp() error {
 		fmt.Printf("\nWaiting for Docker daemon to start...\n")
 	}
 
-	time.Sleep(600 * time.Millisecond)
+	time.Sleep(time.Duration(B2D.Waittime) * time.Millisecond)
 	socket := ""
-	for i := 1; i < 30; i++ {
-		print(".")
+	for i := 1; i < B2D.Retries; i++ {
+		print("o")
 		if socket, err = RequestSocketFromSSH(m); err == nil {
 			break
 		}
@@ -119,7 +119,7 @@ func cmdUp() error {
 
 	if socket == "" {
 		// lets try one more time
-		time.Sleep(600 * time.Millisecond)
+		time.Sleep(time.Duration(B2D.Waittime) * time.Millisecond)
 		fmt.Printf("  Trying to get Docker socket one more time\n")
 
 		if socket, err = RequestSocketFromSSH(m); err != nil {

--- a/config.go
+++ b/config.go
@@ -118,6 +118,9 @@ func config() (*flag.FlagSet, error) {
 	flags.IPVar(&B2D.LowerIP, "lowerip", net.ParseIP("192.168.59.103"), "VirtualBox host-only network DHCP lower bound.")
 	flags.IPVar(&B2D.UpperIP, "upperip", net.ParseIP("192.168.59.254"), "VirtualBox host-only network DHCP upper bound.")
 
+	flags.IntVar(&B2D.Waittime, "waittime", 300, "Time in milliseconds to wait between port knocking retries during 'start'")
+	flags.IntVar(&B2D.Retries, "retries", 40, "number of port knocking retries during 'start'")
+
 	if runtime.GOOS != "windows" {
 		//SerialFile ~~ filepath.Join(dir, B2D.vm+".sock")
 		flags.StringVar(&B2D.SerialFile, "serialfile", "", "path to the serial socket/pipe.")

--- a/driver/config.go
+++ b/driver/config.go
@@ -40,6 +40,10 @@ type MachineConfig struct {
 	Serial     bool
 	SerialFile string
 
+	// boot2docker init retry settings
+	Waittime int
+	Retries  int
+
 	DriverCfg map[string]interface{}
 }
 


### PR DESCRIPTION
...place with extra retries and add cmdline flag in case someone has a much slower system

replaces #270, which didn't do enough for the VM I have.
- this increases the number of retries (ie, has no effect on faster booting systems),
- adds a `--retries=45` and `--waittime=300` flags to allow it to be set in someone's `config` file
- changes one of the `.` 's into `o`, so you can tell the difference between wait for sshd and then wait for docker daemon

@gmlewis @bfirsh, @tianon please consider :)
