### PR TITLE
Update default ISO path to prefer an ISO that's next to the boot2docker CLI binary

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -61,6 +62,36 @@ func cfgFilename(dir string) string {
 	return filename
 }
 
+func defaultIsoPath(dir string) string {
+	var err error
+
+	iso := filepath.Join(dir, "boot2docker.iso")
+
+	exe := os.Args[0]
+	if filepath.Base(exe) == exe {
+		// this logic borrowed from reexec/reexec.go in Docker itself :)
+		if lp, err := exec.LookPath(exe); err == nil {
+			exe = lp
+		}
+	}
+
+	if exe, err = filepath.Abs(exe); err != nil {
+		return iso
+	}
+
+	if exe, err = filepath.EvalSymlinks(exe); err != nil {
+		return iso
+	}
+
+	// if there's a "boot2docker.iso" next to our boot2docker-cli executable, let's prefer that one by default
+	exeIso := filepath.Join(filepath.Dir(exe), "boot2docker.iso")
+	if _, err = os.Stat(exeIso); err == nil {
+		return exeIso
+	}
+
+	return iso
+}
+
 // Write configuration set by the combination of profile and flags
 //    Should result in a format that can be piped into a profile file
 func printConfig() string {
@@ -92,7 +123,7 @@ func config() (*flag.FlagSet, error) {
 	//flags.StringVarP(&B2D.Dir, "dir", "d", dir, "boot2docker config directory.")
 	B2D.Dir = dir
 	flags.StringVar(&B2D.ISOURL, "iso-url", "https://api.github.com/repos/boot2docker/boot2docker/releases", "source URL to provision the boot2docker ISO image.")
-	flags.StringVar(&B2D.ISO, "iso", filepath.Join(dir, "boot2docker.iso"), "path to boot2docker ISO image.")
+	flags.StringVar(&B2D.ISO, "iso", defaultIsoPath(dir), "path to boot2docker ISO image.")
 
 	// Sven disabled this, as it is broken - if I user with a fresh computer downloads
 	// just the boot2docker-cli, and then runs `boot2docker --init ip`, we create a vm


### PR DESCRIPTION
This is especially important for places like the Windows installer, where we want people to be able to install boot2docker 1.3 from an installer, and it includes the right ISO, so when they boot their VM, it should also be boot2docker 1.3, without any extra work or extra downloading.
