### PR TITLE
Report the iso path used by the vm to help debug possible support issues

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -329,9 +329,13 @@ func cmdInfo() error {
 	if err != nil {
 		return fmt.Errorf("Failed to get machine %q: %s", B2D.VM, err)
 	}
-	if err := json.NewEncoder(os.Stdout).Encode(m); err != nil {
+	b, err := json.MarshalIndent(m, "", "\t")
+	if err != nil {
 		return fmt.Errorf("Failed to encode machine %q info: %s", B2D.VM, err)
 	}
+
+	os.Stdout.Write(b)
+
 	return nil
 }
 

--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -161,6 +161,7 @@ func (f Flag) Get(o Flag) string {
 type Machine struct {
 	Name       string
 	UUID       string
+	Iso        string
 	State      driver.MachineState
 	CPUs       uint
 	Memory     uint // main memory (in MB)
@@ -355,6 +356,8 @@ func GetMachine(id string) (*Machine, error) {
 			m.Name = val
 		case "UUID":
 			m.UUID = val
+		case "SATA-0-0":
+			m.Iso = val
 		case "VMState":
 			m.State = driver.MachineState(val)
 		case "memory":


### PR DESCRIPTION
Follow-on for #287 

While testing I was tripped up by the fact that one of my boxes has a `~/.boot2docker/profile` I'd forgotten - and without a b2d way to find out what the iso file path really is, we'd have to resort to asking users to tell us (rather than c&p), which is fraught with extra round trips.

at the same time, I've formatted the json so its readable.

@tianon @gmlewis 
