### PR TITLE
Starting from saved state skips setUpShares

### DIFF
--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -195,11 +195,14 @@ func (m *Machine) Start() error {
 	switch m.State {
 	case driver.Paused:
 		return vbm("controlvm", m.Name, "resume")
-	case driver.Poweroff, driver.Saved, driver.Aborted:
+	case driver.Poweroff, driver.Aborted:
 		if err := m.setUpShares(); err != nil {
 			return err
 		}
+		fallthrough
+	case driver.Saved:
 		return vbm("startvm", m.Name, "--type", "headless")
+
 	}
 	if err := m.Refresh(); err == nil {
 		if m.State != driver.Running {


### PR DESCRIPTION
When trying to  start from saved state, virtualbox.setUpShares() fails while running:

```
VBoxManage guestproperty set boot2docker-vm /VirtualBox/GuestAdd/SharedFolders/MountPrefix /
```

The error message gives a hint: `VBoxManage: error: The machine is not mutable (state is Saved)`

Fixes #292
