### PR TITLE
printExport support for fish-shell

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -199,7 +199,7 @@ func printExport(socket, certPath string) {
 			if value == "" {
 				fmt.Printf("    set -e %s\n", name)
 			} else {
-				fmt.Printf("    set -x %s\n", name)
+				fmt.Printf("    set -x %s %s\n", name, value)
 			}
 		default: // default command to export variables POSIX shells, like bash, zsh, etc.
 			if value == "" {


### PR DESCRIPTION
This is, basically, just an upstream update of boot2docker/boot2docker-cli#260. I just didn't used @kevinbin commits 'cause I couldn't find his repo anymore to merge with my remote.
