### PR TITLE
Refine tls logic for shellInit

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -171,10 +171,18 @@ func cmdShellInit() error {
 		return fmt.Errorf("Error requesting socket: %s\n", err)
 	}
 
-	certPath, err := RequestCertsUsingSSH(m)
+	tlsVerify, err := RequestTLSVerifyUsingSSH(m)
 	if err != nil {
-		// These errors are not fatal
-		fmt.Fprintf(os.Stderr, "Warning: error copying certificates: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: error getting tlsVerify: %s\n", err)
+	}
+
+	certPath := ""
+	if tlsVerify {
+		certPath, err = RequestCertsUsingSSH(m)
+		if err != nil {
+			// These errors are not fatal
+			fmt.Fprintf(os.Stderr, "Warning: error copying certificates: %s\n", err)
+		}
 	}
 	printExport(socket, certPath)
 

--- a/util.go
+++ b/util.go
@@ -350,3 +350,22 @@ func RequestCertsUsingSSH(m driver.Machine) (string, error) {
 	}
 	return certDir, nil
 }
+
+func RequestTLSVerifyUsingSSH(m driver.Machine) (bool, error) {
+	// without true it is hard to decide if grep or ssh caused the non 0 return
+	cmd := getSSHCommand(m, "grep tlsverify /proc/$(cat /var/run/docker.pid)/cmdline || true")
+
+	tlsVerify := false
+
+	b, err := cmd.Output()
+	if err != nil {
+		return tlsVerify, err
+	}
+	out := string(b)
+	if B2D.Verbose {
+		fmt.Printf("SSH returned: %s\nEND SSH\n", out)
+	}
+
+	tlsVerify = strings.Index(out, "--tlsverify") != -1
+	return tlsVerify, nil
+}


### PR DESCRIPTION
Right now shellinit relies on pem files existence when decides about setting `DOCKER_TLS_VERIFY` and `DOCKER_CERT_PATH`.

checking `--tlsverify` option at server side is more reliable.