### PR TITLE
Make "socket" an alias of "shellinit" and hide it from usage

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -349,29 +349,6 @@ func cmdStatus() error {
 	return nil
 }
 
-// tell the User the Docker socket to connect to
-func cmdSocket() error {
-	m, err := driver.GetMachine(&B2D)
-	if err != nil {
-		return fmt.Errorf("Failed to get machine %q: %s", B2D.VM, err)
-	}
-
-	if m.GetState() != driver.Running {
-		return fmt.Errorf("VM %q is not running.", B2D.VM)
-	}
-
-	socket, err := RequestSocketFromSSH(m)
-	if err != nil {
-		return fmt.Errorf("Error requesting socket: %s\n", err)
-	}
-
-	fmt.Fprintf(os.Stderr, "\n\t export DOCKER_HOST=")
-	fmt.Printf("%s", socket)
-	fmt.Fprintf(os.Stderr, "\n\n")
-
-	return nil
-}
-
 // Call the external SSH command to login into boot2docker VM.
 func cmdSSH() error {
 	m, err := driver.GetMachine(&B2D)

--- a/config.go
+++ b/config.go
@@ -171,7 +171,7 @@ func config() (*flag.FlagSet, error) {
 }
 
 func usageShort() {
-	fmt.Fprintf(os.Stderr, "Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|socket|shellinit|delete|download|upgrade|version} [<args>]\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|shellinit|delete|download|upgrade|version} [<args>]\n", os.Args[0])
 }
 
 func usageLong(flags *flag.FlagSet) {
@@ -193,8 +193,7 @@ Commands:
    config|cfg          Show selected profile file settings.
    info                Display detailed information of VM.
    ip                  Display the IP address of the VM's Host-only network.
-   socket              Display the DOCKER_HOST socket to connect to.
-   shellinit           Display the shell command to set up the Docker client.
+   shellinit           Display the shell commands to set up the Docker client.
    status              Display current state of VM.
    download            Download Boot2Docker ISO image.
    upgrade             Upgrade the Boot2Docker ISO image (restart if running).

--- a/main.go
+++ b/main.go
@@ -65,9 +65,7 @@ func run() error {
 		return cmdDelete()
 	case "info":
 		return cmdInfo()
-	case "socket":
-		return cmdSocket()
-	case "shellinit":
+	case "shellinit", "socket":
 		return cmdShellInit()
 	case "status":
 		return cmdStatus()


### PR DESCRIPTION
Fixes boot2docker/boot2docker#585

For the other things discussed there (ie, showing _all_ env variables regardless of their current state), see #295.
