### PR TITLE
Refine tls logic for shellInit v2

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -171,10 +171,18 @@ func cmdShellInit() error {
 		return fmt.Errorf("Error requesting socket: %s\n", err)
 	}
 
-	certPath, err := RequestCertsUsingSSH(m)
+	tlsVerify, err := RequestTLSUsingSSH(m)
 	if err != nil {
-		// These errors are not fatal
-		fmt.Fprintf(os.Stderr, "Warning: error copying certificates: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: error getting tlsVerify: %s\n", err)
+	}
+
+	certPath := ""
+	if tlsVerify {
+		certPath, err = RequestCertsUsingSSH(m)
+		if err != nil {
+			// These errors are not fatal
+			fmt.Fprintf(os.Stderr, "Warning: error copying certificates: %s\n", err)
+		}
 	}
 
 	// Check if $DOCKER_* ENV vars are properly configured.

--- a/util.go
+++ b/util.go
@@ -26,6 +26,13 @@ var (
 	versionRe = regexp.MustCompile(`(\d+\.?){3}`)
 )
 
+const (
+	SSHCommGetIp      = "ip addr show dev eth1"
+	SSHCommGetTcp     = "grep tcp:// /proc/$(cat /var/run/docker.pid)/cmdline"
+	SSHCommTarPems    = "tar c /home/docker/.docker/*.pem"
+	SSHCommDaemonArgs = "xargs -0 <  /proc/$(cat /var/run/docker.pid)/cmdline"
+)
+
 // Try if addr tcp://addr is readable for n times at wait interval.
 func read(addr string, n int, wait time.Duration) error {
 	var lastErr error
@@ -155,10 +162,7 @@ func getLocalClientVersion() (string, error) {
 }
 
 func cmdInteractive(m driver.Machine, args ...string) error {
-	cmd := getSSHCommand(m, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd := getSSHCommandWithStd(m, args...)
 	return cmd.Run()
 }
 
@@ -193,7 +197,36 @@ func reader(r io.Reader) {
 	}
 }
 
-func getSSHCommand(m driver.Machine, args ...string) *exec.Cmd {
+type GetSSHCommandFunc func(m driver.Machine, args ...string) Outputer
+
+var sshProvider GetSSHCommandFunc
+
+func init() {
+
+	sshProvider = WrapperGetSSHCommand
+}
+
+func getSSHCommandWithStd(m driver.Machine, args ...string) *exec.Cmd {
+	cmd := DeafaultGetSSHCommand(m, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd
+}
+
+type Outputer interface {
+	Output() ([]byte, error)
+}
+
+func getSSHCommand(m driver.Machine, args ...string) Outputer {
+	return sshProvider(m, args...)
+}
+
+func WrapperGetSSHCommand(m driver.Machine, args ...string) Outputer {
+	return DeafaultGetSSHCommand(m, args...)
+}
+
+func DeafaultGetSSHCommand(m driver.Machine, args ...string) *exec.Cmd {
 
 	DefaultSSHArgs := []string{
 		"-o", "IdentitiesOnly=yes",
@@ -216,7 +249,7 @@ func getSSHCommand(m driver.Machine, args ...string) *exec.Cmd {
 }
 
 func RequestIPFromSSH(m driver.Machine) (string, error) {
-	cmd := getSSHCommand(m, "ip addr show dev eth1")
+	cmd := getSSHCommand(m, SSHCommGetIp)
 
 	b, err := cmd.Output()
 	if err != nil {
@@ -239,7 +272,7 @@ func RequestIPFromSSH(m driver.Machine) (string, error) {
 }
 
 func RequestSocketFromSSH(m driver.Machine) (string, error) {
-	cmd := getSSHCommand(m, "grep tcp:// /proc/$(cat /var/run/docker.pid)/cmdline")
+	cmd := getSSHCommand(m, SSHCommGetTcp)
 
 	b, err := cmd.Output()
 	if err != nil {
@@ -330,7 +363,7 @@ func RequestIPFromSerialPort(socket string) (string, error) {
 // certs in the local host's user dir, that the server is using them, so
 // for now, make sure things are updated from the server. (for `docker shellinit`)
 func RequestCertsUsingSSH(m driver.Machine) (string, error) {
-	cmd := getSSHCommand(m, "tar c /home/docker/.docker/*.pem")
+	cmd := getSSHCommand(m, SSHCommTarPems)
 
 	certDir := ""
 
@@ -375,4 +408,33 @@ func RequestCertsUsingSSH(m driver.Machine) (string, error) {
 		}
 	}
 	return certDir, nil
+}
+
+func getDaemonArgumentsUsingSSH(m driver.Machine) ([]string, error) {
+	cmd := getSSHCommand(m, SSHCommDaemonArgs)
+
+	b, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	out := string(b)
+	if B2D.Verbose {
+		fmt.Printf("SSH returned: %s\nEND SSH\n", out)
+	}
+	return strings.Split(out, " "), nil
+}
+
+func RequestTLSUsingSSH(m driver.Machine) (bool, error) {
+	args, err := getDaemonArgumentsUsingSSH(m)
+	if err != nil {
+		return false, err
+	}
+
+	for _, a := range args {
+		if a == "--tlsverify" || a == "--tls" {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/boot2docker/boot2docker-cli/driver"
+	"github.com/boot2docker/boot2docker-cli/dummy"
+)
+
+type FixedOutputer struct {
+	output []byte
+}
+
+func (f FixedOutputer) Output() ([]byte, error) {
+	return f.output, nil
+}
+
+func NewFixedOutputerStr(o string) FixedOutputer {
+	return FixedOutputer{[]byte(o)}
+}
+
+func NewFixedOutputerByte(b []byte) FixedOutputer {
+	return FixedOutputer{b}
+}
+
+type FakeSshCommander struct {
+	builtIns map[string]Outputer
+}
+
+func NewFakeSshCommander() FakeSshCommander {
+	f := FakeSshCommander{
+		builtIns: map[string]Outputer{},
+	}
+	return f
+}
+
+func (f FakeSshCommander) AddCmdOut(cmd string, out string) {
+	f.builtIns[cmd] = NewFixedOutputerStr(out)
+}
+
+func (f FakeSshCommander) AddTarCmd() {
+	f.builtIns[SSHCommTarPems] = NewFixedOutputerByte(getTarBtes())
+}
+
+func getTarBtes() []byte {
+	buf := new(bytes.Buffer)
+
+	tw := tar.NewWriter(buf)
+
+	body := "delme now"
+	hdr := &tar.Header{
+		Name: "delme.pem",
+		Size: int64(len(body)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		log.Fatalln(err)
+	}
+	if _, err := tw.Write([]byte(body)); err != nil {
+		log.Fatalln(err)
+	}
+
+	if err := tw.Close(); err != nil {
+		log.Fatalln(err)
+	}
+	return buf.Bytes()
+}
+
+func (f FakeSshCommander) GetSshCommand(m driver.Machine, args ...string) Outputer {
+	a := strings.Join(args, " ")
+	o := f.builtIns[a]
+	return o
+}
+
+func TestRequestIPFromSSHFull(t *testing.T) {
+	fc := NewFakeSshCommander()
+	fc.AddCmdOut(SSHCommGetIp, `4: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+  link/ether 08:00:27:8f:93:ba brd ff:ff:ff:ff:ff:ff
+  inet 111.222.111.222/24 brd 192.168.59.255 scope global eth1
+     valid_lft forever preferred_lft forever
+  inet6 fe80::a00:27ff:fe8f:93ba/64 scope link
+     valid_lft forever preferred_lft forever`)
+	sshProvider = fc.GetSshCommand
+
+	ip, err := RequestIPFromSSH(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ip != "111.222.111.222" {
+		t.Fatalf("Expected 111.222.111.222 got %s", ip)
+	}
+
+}
+
+func TestRequestSocketFromSSHZero(t *testing.T) {
+	fc := NewFakeSshCommander()
+
+	fc.AddCmdOut(SSHCommGetTcp, `tcp://0.0.0.0:2375`)
+	fc.AddCmdOut(SSHCommGetIp, `4: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 08:00:27:8f:93:ba brd ff:ff:ff:ff:ff:ff
+    inet 192.168.59.103/24 brd 192.168.59.255 scope global eth1
+       valid_lft forever preferred_lft forever
+    inet6 fe80::a00:27ff:fe8f:93ba/64 scope link
+       valid_lft forever preferred_lft forever`)
+
+	fc.AddCmdOut(SSHCommDaemonArgs, `/usr/local/bin/docker -d -D -g /var/lib/docker -H unix:// -H tcp://0.0.0.0:2375 -b=bridge0 --registry-mirror=http://192.168.1.111:5000`)
+	sshProvider = fc.GetSshCommand
+
+	s, err := RequestSocketFromSSH(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s != "tcp://192.168.59.103:2375" {
+		t.Fatalf("Expected tcp://192.168.59.103:2375 got %s", s)
+	}
+
+}
+
+func TestRequestSocketFromSSH(t *testing.T) {
+	fc := NewFakeSshCommander()
+
+	fc.AddCmdOut(SSHCommGetTcp, `tcp://1.2.3.4:2375`)
+	fc.AddCmdOut(SSHCommGetIp, `4: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 08:00:27:8f:93:ba brd ff:ff:ff:ff:ff:ff
+    inet 192.168.59.103/24 brd 192.168.59.255 scope global eth1
+       valid_lft forever preferred_lft forever
+    inet6 fe80::a00:27ff:fe8f:93ba/64 scope link
+       valid_lft forever preferred_lft forever`)
+
+	fc.AddCmdOut(SSHCommDaemonArgs, `/usr/local/bin/docker --tlsverify -d -D -g /var/lib/docker -H unix:// -H tcp://0.0.0.0:2375 -b=bridge0 --registry-mirror=http://192.168.1.111:5000`)
+	sshProvider = fc.GetSshCommand
+
+	s, err := RequestSocketFromSSH(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s != "tcp://1.2.3.4:2375" {
+		t.Fatalf("Expected tcp://1.2.3.4:2375 got %s", s)
+	}
+}
+
+func getDummyMachine() driver.Machine {
+	c := driver.MachineConfig{
+		VM:      "dummy",
+		SSHPort: 22,
+	}
+	m, _ := dummy.InitFunc(&c)
+	return m
+}
+
+func TestRequestCertsUsingSSH(t *testing.T) {
+	fc := NewFakeSshCommander()
+
+	fc.AddCmdOut(SSHCommGetTcp, `tcp://1.2.3.4:2375`)
+	fc.AddCmdOut(SSHCommGetIp, `4: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 08:00:27:8f:93:ba brd ff:ff:ff:ff:ff:ff
+    inet 192.168.59.103/24 brd 192.168.59.255 scope global eth1
+       valid_lft forever preferred_lft forever
+    inet6 fe80::a00:27ff:fe8f:93ba/64 scope link
+       valid_lft forever preferred_lft forever`)
+
+	fc.AddCmdOut(SSHCommDaemonArgs, `/usr/local/bin/docker --tlsverify -d -D -g /var/lib/docker -H unix:// -H tcp://0.0.0.0:2375 -b=bridge0 --registry-mirror=http://192.168.1.111:5000`)
+	fc.AddTarCmd()
+	sshProvider = fc.GetSshCommand
+
+	m := getDummyMachine()
+	certDir, err := RequestCertsUsingSSH(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(certDir, "dummy") {
+		t.Fatalf("Expected has suffix: dummy got %s", certDir)
+	}
+}
+
+func TestRequestTLSUsingSSHNoTLS(t *testing.T) {
+	fc := NewFakeSshCommander()
+	fc.AddCmdOut(SSHCommDaemonArgs, `/usr/local/bin/docker -d -D -g /var/lib/docker -H unix:// -H tcp://0.0.0.0:2375 -b=bridge0 --registry-mirror=http://192.168.1.111:5000`)
+	sshProvider = fc.GetSshCommand
+
+	m := getDummyMachine()
+	b, err := RequestTLSUsingSSH(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b {
+		t.Fatalf("Expected false got %b", b)
+	}
+}
+
+func TestRequestTLSVerifyUsingSSHTLS(t *testing.T) {
+	fc := NewFakeSshCommander()
+	fc.AddCmdOut(SSHCommDaemonArgs, `/usr/local/bin/docker --tlsverify -d -D -g /var/lib/docker -H unix:// -H tcp://0.0.0.0:2375 -b=bridge0 --registry-mirror=http://192.168.1.111:5000`)
+	sshProvider = fc.GetSshCommand
+
+	m := getDummyMachine()
+	b, err := RequestTLSUsingSSH(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b {
+		t.Fatalf("Expected true got %b", b)
+	}
+}
+
+func TestRequestTLSUsingSSHTLS(t *testing.T) {
+	fc := NewFakeSshCommander()
+	fc.AddCmdOut(SSHCommDaemonArgs, `/usr/local/bin/docker --tls -d -D -g`)
+	sshProvider = fc.GetSshCommand
+
+	m := getDummyMachine()
+	b, err := RequestTLSUsingSSH(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b {
+		t.Fatalf("Expected true got %b", b)
+	}
+}


### PR DESCRIPTION
Instead of the hacky grep of #298 lets just get all the docker daemon arguments as []string.
