### PR TITLE
Run boot scripts after init/up

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -456,7 +456,6 @@ func runScript(name string) error {
 		return fmt.Errorf("Failed to run %s: %s\n", name, err)
 	}
 	fname := filepath.Join(dir, name)
-	println(fname)
 	if _, err := os.Stat(fname); err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("Failed to run %s: %s\n", name, err)


### PR DESCRIPTION
This is very small change but it's very useful change (for me at least)
I'm using boot2docker under http proxy environment. So I need to add following lines into `/var/lib/boot2docker/profile` at any time after `boot2docker init`.

```
export HTTP_PROXY=my.proxy.server:8080
export HTTPS_PROXY=my.proxy.server:8080
```

I must do this again when `boot2docker delete`,  `boot2docker init`. If boot2docker runs script after init/up, do you think it's useful, don't you?

This change allow to run `~/.boot2docker/boot-init.sh` after `boot2docker init`,  And run `~/.boot2docker/boot-up.sh` after `boot2docker up`. How do you think?

ex:

boot-init.sh

```
#!/bin/sh

sudo tee /var/lib/boot2docker/profile <<EOF >/dev/null
export http_proxy=http://my.proxy.server:8080
export https_proxy=http://my.proxy.server:8080
EOF
```

boot-up.sh

```
#!/bin/sh

sudo modprobe vboxsf && mount -t vboxsf C/Users /Users
```
