### PR TITLE
remove the library path before we exec

### DIFF
--- a/virtualbox/vbm.go
+++ b/virtualbox/vbm.go
@@ -9,12 +9,18 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/boot2docker/boot2docker-cli/driver"
 )
 
 func init() {
+	if runtime.GOOS == "darwin" {
+		// remove DYLD_LIBRARY_PATH and LD_LIBRARY_PATH as they break VBoxManage on OSX
+		os.Setenv("DYLD_LIBRARY_PATH", "")
+		os.Setenv("LD_LIBRARY_PATH", "")
+	}
 }
 
 var (


### PR DESCRIPTION
In a fix to #148, I added unsetting these env vars into the Boot2Docker.app - but then reading #606 made me realise it should really be done in b2d-cli itself.

so 

Fixes #606 - maybe

This needs testing on a setup that has these env vars tho, as mine works all the time - i presume you need more dev tols installed locally?
