### PR TITLE
Remove "boot2docker ip" stderr output

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -411,9 +411,7 @@ func cmdIP() error {
 		}
 	}
 	if IP != "" {
-		fmt.Fprintf(os.Stderr, "\nThe VM's Host only interface IP address is: ")
-		fmt.Printf("%s", IP)
-		fmt.Fprintf(os.Stderr, "\n\n")
+		fmt.Println(IP)
 	} else {
 		fmt.Fprintf(os.Stderr, "\nFailed to get VM Host only IP address.\n")
 		fmt.Fprintf(os.Stderr, "\tWas the VM initialized using boot2docker?\n")


### PR DESCRIPTION
It confuses folks far too often, so as pretty as it is, it ought to go so we stop having to answer the same question over and over.

Fixes #310
