### PR TITLE
Explicitly use the VirtualBox NAT DNS Proxy

### DIFF
--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -633,9 +633,13 @@ func (m *Machine) Modify() error {
 		"--firmware", "bios",
 		"--bioslogofadein", "off",
 		"--bioslogofadeout", "off",
-		"--natdnshostresolver1", "on",
 		"--bioslogodisplaytime", "0",
 		"--biosbootmenu", "disabled",
+
+		// VirtualBox's DNS Host Resolver doesn't support SRV records
+		// direct DNS pass-through doesn't support roaming laptops well
+		// so we explicitly enable the DNS proxy
+		"--natdnsproxy1", "on",
 
 		"--ostype", m.OSType,
 		"--cpus", fmt.Sprintf("%d", m.CPUs),


### PR DESCRIPTION
Fixes https://github.com/boot2docker/boot2docker/issues/627
