### PR TITLE
Switch to Go 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 # this should be exactly the same as what's in the Dockerfile
-go: 1.3
+go: 1.4
 
 # let us have pretty experimental Docker-based Travis workers
 sudo: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Dockerfile to cross compile boot2docker-cli
 
-FROM golang:1.3-cross
+FROM golang:1.4-cross
 
 WORKDIR /go/src/github.com/boot2docker/boot2docker-cli
 
 # Download (but not install) dependencies
 RUN go get -v github.com/BurntSushi/toml
-RUN go get -v github.com/ogier/pflag 
+RUN go get -v github.com/ogier/pflag
 
 ADD . /go/src/github.com/boot2docker/boot2docker-cli
 


### PR DESCRIPTION
See #324 for one specific rationale for switching.  The other solid rationale would be that we compile successfully, and Go 1.4 includes some nice compiler improvements that it can't hurt to take advantage of. :+1: