### PR TITLE
Support github enterprise release urls for ISO

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -576,12 +576,11 @@ func cmdDownload() error {
 		host := matches[1]
 		org := matches[3]
 		repo := matches[4]
-		fmt.Printf("Latest release for %s/%s is %s\n", org, repo, tag)
 		if host == "api.github.com" {
-			url = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/boot2docker.iso", org, repo, tag)
-		} else {
-			url = fmt.Sprintf("https://%s/%s/%s/releases/download/%s/boot2docker.iso", host, org, repo, tag)
+			host = "github.com"
 		}
+		fmt.Printf("Latest release for %s/%s/%s is %s\n", host, org, repo, tag)
+		url = fmt.Sprintf("https://%s/%s/%s/releases/download/%s/boot2docker.iso", host, org, repo, tag)
 	}
 
 	fmt.Println("Downloading boot2docker ISO image...")

--- a/cmds.go
+++ b/cmds.go
@@ -564,16 +564,24 @@ func cmdIP() error {
 func cmdDownload() error {
 	url := B2D.ISOURL
 
-	re := regexp.MustCompile("https://api.github.com/repos/([^/]+)/([^/]+)/releases")
-	if matches := re.FindStringSubmatch(url); len(matches) == 3 {
+	// match github (enterprise) release urls:
+	// https://api.github.com/repos/../../relases or
+	// https://some.github.enterprise/api/v3/repos/../../relases
+	re := regexp.MustCompile("https://([^/]+)(/api/v3)?/repos/([^/]+)/([^/]+)/releases")
+	if matches := re.FindStringSubmatch(url); len(matches) == 5 {
 		tag, err := getLatestReleaseName(url)
 		if err != nil {
 			return fmt.Errorf("Failed to get latest release: %s", err)
 		}
-		org := matches[1]
-		repo := matches[2]
+		host := matches[1]
+		org := matches[3]
+		repo := matches[4]
 		fmt.Printf("Latest release for %s/%s is %s\n", org, repo, tag)
-		url = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/boot2docker.iso", org, repo, tag)
+		if host == "api.github.com" {
+			url = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/boot2docker.iso", org, repo, tag)
+		} else {
+			url = fmt.Sprintf("https://%s/%s/%s/releases/download/%s/boot2docker.iso", host, org, repo, tag)
+		}
 	}
 
 	fmt.Println("Downloading boot2docker ISO image...")


### PR DESCRIPTION
This adds support for `ISOURL`  pointing to *GitHub Enterprise* release API urls. 

So this makes the reggae to match
 * `https://api.github.com/repos/$ORG/$REPO/releases`
 * `https://some.host/api/v3/$ORG/$REPO/releases`

Background: We need to maintain a fork of the boot2docker.iso on our internal github applicance to make it work inside our sealed corporate network. Having the `boot2docker download` and `boot2docker upgrade` work for us would be a blast.

Cheers