### PR TITLE
Fixes #209: CLI option for number of CPUs when creating a new boot2docker VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ DiskSize = 20000
 # VM memory size in MB
 Memory = 2048
 
+# Number of CPUs
+CPUs = 1
+
 # host port forwarding to port 22 in the VM
 SSHPort = 2022
 

--- a/config.go
+++ b/config.go
@@ -116,6 +116,7 @@ func config() (*flag.FlagSet, error) {
 	flags.StringVar(&B2D.SSHKey, "sshkey", filepath.Join(sshdir, "id_boot2docker"), "path to SSH key to use.")
 	flags.UintVarP(&B2D.DiskSize, "disksize", "s", 20000, "boot2docker disk image size (in MB).")
 	flags.UintVarP(&B2D.Memory, "memory", "m", 2048, "virtual machine memory size (in MB).")
+	flags.UintVarP(&B2D.CPUs, "cpus", "c", uint(runtime.NumCPU()), "number of CPUs for boot2docker.")
 	flags.Uint16Var(&B2D.SSHPort, "sshport", 2022, "host SSH port (forward to port 22 in VM).")
 	flags.Uint16Var(&B2D.DockerPort, "dockerport", 0, "host Docker port (forward to port 2376 in VM). (deprecated - use with care)")
 	flags.IPVar(&B2D.HostIP, "hostip", net.ParseIP("192.168.59.3"), "VirtualBox host-only network IP address.")

--- a/driver/config.go
+++ b/driver/config.go
@@ -26,6 +26,7 @@ type MachineConfig struct {
 	ISO                  string // boot2docker ISO image path
 	DiskSize             uint   // VM disk image size (MB)
 	Memory               uint   // VM memory size (MB)
+	CPUs                 uint   // Number of CPUs
 
 	// NAT network: port forwarding
 	SSHPort    uint16 // host SSH port (forward to port 22 in VM)

--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -466,7 +466,11 @@ func CreateMachine(mc *driver.MachineConfig) (*Machine, error) {
 	// Configure VM for Boot2docker
 	SetExtra(mc.VM, "VBoxInternal/CPUM/EnableHVP", "1")
 	m.OSType = "Linux26_64"
-	m.CPUs = uint(runtime.NumCPU())
+	if mc.CPUs > 0 {
+		m.CPUs = mc.CPUs
+	} else {
+		m.CPUs = uint(runtime.NumCPU())
+	}
 	if m.CPUs > 32 {
 		m.CPUs = 32
 	}


### PR DESCRIPTION
This pull request enhances boot2docker init by allowing user to pass --cpus to configure the number of cpus allocated to boot2docker-vm during vm creation.