### PR TITLE
ErrMachineNotExist msg: Fix grammar, more helpful

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -52,7 +52,7 @@ var (
 	machines map[string]InitFunc
 
 	ErrNotSupported    = errors.New("driver not supported")
-	ErrMachineNotExist = errors.New("machine not exist")
+	ErrMachineNotExist = errors.New("machine does not exist (Did you run `boot2docker init`?)")
 	ErrMachineExist    = errors.New("machine already exists")
 	ErrPrerequisites   = errors.New("prerequisites for machine not satisfied (hypervisor installed?)")
 )


### PR DESCRIPTION
This adds the word "does" to make it sound nicer and it also asks if the user ran `boot2docker init`.

Instead of:

```
$ boot2docker status
error in run: Failed to get machine "boot2docker-vm": machine not exist
```

the user gets:

```
$ boot2docker status
error in run: Failed to get machine "boot2docker-vm": machine does not exist
(Did you run `boot2docker init`?)
```