### PR TITLE
Add sharing support for linux

### DIFF
--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -133,6 +133,9 @@ func ConfigFlags(B2D *driver.MachineConfig, flags *flag.FlagSet) error {
 		shareDefault = "/Users" + shareSliceSep + "Users"
 	case "windows":
 		shareDefault = "C:\\Users" + shareSliceSep + "c/Users"
+	case "linux":
+		// This needs to be Users on the VB side since /home already exists in the VM
+		shareDefault = "/home" + shareSliceSep + "Users"
 	}
 
 	var defaultText string


### PR DESCRIPTION
We are actually using the boot2docker-cli for the linux version of the Kalabox2 project. Would be great to just add this small piece in to get shares happening via boot2docker up/down instead of with an extra VBoxManage command on the Kalabox side.
