### PR TITLE
add NO_PROXY variable to shellinit with boot2docker ip

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -237,21 +237,21 @@ func exports(socket, certPath string) map[string]string {
 			ip := matches[1]
 
 			//first check for an existing lower case no_proxy var
-			no_proxy_var := "no_proxy"
-			no_proxy_value := os.Getenv("no_proxy")
 			//otherweise try allcaps HTTP_PROXY
-			if no_proxy_value == "" {
-				no_proxy_var = "NO_PROXY"
-				no_proxy_value = os.Getenv("NO_PROXY")
+			name := "no_proxy"
+			val := os.Getenv("no_proxy")
+			if val == "" {
+				name = "NO_PROXY"
+				val = os.Getenv("NO_PROXY")
 			}
 
 			switch {
-			case no_proxy_value == "":
-				out[no_proxy_var] = ip
-			case strings.Contains(no_proxy_value, ip):
-				out[no_proxy_var] = no_proxy_value
+			case val == "":
+				out[name] = ip
+			case strings.Contains(val, ip):
+				out[name] = val
 			default:
-				out[no_proxy_var] = fmt.Sprintf("%s,%s", no_proxy_value, ip)
+				out[name] = fmt.Sprintf("%s,%s", val, ip)
 			}
 		}
 	}

--- a/cmds.go
+++ b/cmds.go
@@ -235,9 +235,6 @@ func exports(socket, certPath string) map[string]string {
 		re := regexp.MustCompile("tcp://([^:]+):")
 		if matches := re.FindStringSubmatch(socket); len(matches) == 2 {
 			ip := matches[1]
-
-			//first check for an existing lower case no_proxy var
-			//otherweise try allcaps HTTP_PROXY
 			name := "no_proxy"
 			val := os.Getenv("no_proxy")
 			if val == "" {
@@ -255,7 +252,6 @@ func exports(socket, certPath string) map[string]string {
 			}
 		}
 	}
-
 	return out
 }
 

--- a/cmds.go
+++ b/cmds.go
@@ -231,7 +231,7 @@ func exports(socket, certPath string) map[string]string {
 	//if a http_proxy is set, we need to make sure the boot2docker ip
 	//is added to the NO_PROXY environment variable
 	if os.Getenv("http_proxy") != "" || os.Getenv("HTTP_PROXY") != "" {
-		//get the ip from the docket/DOCKER_HOST
+		//get the ip from socket/DOCKER_HOST
 		re := regexp.MustCompile("tcp://([^:]+):")
 		if matches := re.FindStringSubmatch(socket); len(matches) == 2 {
 			ip := matches[1]


### PR DESCRIPTION
The docker client started to respect the *HTTP_PROXY* environment variable for api calls with version 1.5.

This kind of breaks the boot2docker scenario for us because docker is running on a local VM in a private network which is not reachable by our corporate proxy.

This pull request changes `boot2docker shellinit` to additionally append the *DOCKER_HOST* to the *NO_PROXY* variable.

I think this is a useful change in general because even before the docker client used *HTTP_PROXY* it was not possible to access http(s) ports exposed by containers without modifying the *NO_PROXY* var.