### PR TITLE
fix IPV6NetworkMaskPrefixLength value parsing #347

### DIFF
--- a/virtualbox/hostonlynet.go
+++ b/virtualbox/hostonlynet.go
@@ -100,7 +100,7 @@ func HostonlyNets() (map[string]*HostonlyNet, error) {
 		case "IPV6Address":
 			n.IPv6.IP = net.ParseIP(val)
 		case "IPV6NetworkMaskPrefixLength":
-			l, err := strconv.ParseUint(val, 10, 7)
+			l, err := strconv.ParseUint(val, 10, 8)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
IPV6NetworkMaskPrefixLength can be "128". bit size parameter for ParseUint needs to be increased to fix error.

fixes #347