### PR TITLE
Print only base binary name in usage string (win)

### DIFF
--- a/config.go
+++ b/config.go
@@ -178,7 +178,8 @@ func config() (*flag.FlagSet, error) {
 }
 
 func usageShort() {
-	fmt.Fprintf(os.Stderr, "Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|shellinit|delete|download|upgrade|version} [<args>]\n", os.Args[0])
+	binName := filepath.Base(os.Args[0])
+	fmt.Fprintf(os.Stderr, "Usage: %s [<options>] {help|init|up|ssh|save|down|poweroff|reset|restart|config|status|info|ip|shellinit|delete|download|upgrade|version} [<args>]\n", binName)
 }
 
 func usageLong(flags *flag.FlagSet) {


### PR DESCRIPTION
When `boot2docker` is called from msys bash shell, usage string prints the
full path of the binary (e.g. `c:\program file\boot2docker for
windows\boot2docker.exe`) in the short usage string.

This change fixes that without breaking the behavior on unix systems or
cmd.exe/powershell on windows which already print the short binary name

## Before/after

![image](https://cloud.githubusercontent.com/assets/159209/6877168/a4d9f8ec-d48b-11e4-80ed-f514644e5861.png)

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>
cc: @tianon 