### PR TITLE
Print exports before unsets for shellinit

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -206,22 +206,27 @@ func isUnixShellOnWindows() bool {
 }
 
 func printExportUnix(values map[string]string) {
+	var exports []string
+	var unsets []string
 	for name, value := range values {
 		switch filepath.Base(os.Getenv("SHELL")) {
 		case "fish":
 			if value == "" {
-				fmt.Printf("    set -e %s\n", name)
+				unsets = append(unsets, fmt.Sprintf("    set -e %s", name))
 			} else {
-				fmt.Printf("    set -x %s %s\n", name, value)
+				exports = append(exports, fmt.Sprintf("    set -x %s %s", name, value))
 			}
 		default: // default command to export variables POSIX shells, like bash, zsh, etc.
 			if value == "" {
-				fmt.Printf("    unset %s\n", name)
+				unsets = append(unsets, fmt.Sprintf("    unset %s", name))
 			} else {
-				fmt.Printf("    export %s=%s\n", name, value)
+				exports = append(exports, fmt.Sprintf("    export %s=%s", name, value))
 			}
 		}
 	}
+	// exports must be declared before unsets for at least bash
+	fmt.Println(strings.Join(exports, "\n"))
+	fmt.Println(strings.Join(unsets, "\n"))
 }
 
 func printExportWindows(values map[string]string) {


### PR DESCRIPTION
Signed-off-by: Peter Edge peter.edge@gmail.com

I have TLS turned off. In my shell:

```
$ bash -version
GNU bash, version 4.3.33(1)-release (x86_64-apple-darwin14.1.0)
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

If `boot2docker shellinit` prints unsets before exports, I get the following:

```
$ x="$(boot2docker shellinit)"; echo $x; $($x)
unset DOCKER_CERT_PATH unset DOCKER_TLS_VERIFY export DOCKER_HOST=tcp://192.168.59.103:2375
bash: unset: `DOCKER_HOST=tcp://192.168.59.103:2375': not a valid identifier
```

It works fine if the exports come first:

```
$ x="$(boot2docker shellinit)"; echo $x; $($x)
export DOCKER_HOST=tcp://192.168.59.103:2375 unset DOCKER_CERT_PATH unset DOCKER_TLS_VERIFY
```

This is a quick fix, this is constantly been an annoyance. I know you have https://github.com/boot2docker/boot2docker-cli/pull/351 going on but this is separate and easily merged. What do you think?
