### PR TITLE
Add checkEnvironment call into cmdHellInit before printExport.

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -176,7 +176,13 @@ func cmdShellInit() error {
 		// These errors are not fatal
 		fmt.Fprintf(os.Stderr, "Warning: error copying certificates: %s\n", err)
 	}
-	printExport(socket, certPath)
+
+	// Check if $DOCKER_* ENV vars are properly configured.
+	if !checkEnvironment(socket, certPath) {
+		printExport(socket, certPath)
+	} else {
+		fmt.Fprintf(os.Stderr, "Your environment variables are already set correctly.\n")
+	}
 
 	return nil
 }


### PR DESCRIPTION
The same as cmdUp does: "Your environment variables are already set correctly." written to stderr in case no actions needed.
This way env correctness can be checked in a script by:

```
if [[ "$(boot2docker-cli shellinit 2>/dev/null)" == "" ]]; then
  # env is ok
else
  # env isn't correct
fi
```