### PR TITLE
Make |boot2docker up| mention `eval "$(boot2docker shellinit)"`

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -147,6 +147,7 @@ func cmdUp() error {
 		if !checkEnvironment(socket, certPath) {
 			fmt.Printf("\nTo connect the Docker client to the Docker daemon, please set:\n")
 			printExport(socket, certPath)
+			fmt.Printf("\nOr run: `eval \"$(boot2docker shellinit)\"`\n")
 		} else {
 			fmt.Printf("Your environment variables are already set correctly.\n")
 		}


### PR DESCRIPTION
Whilst the boot2docker docs have been updated with the improved shellinit pattern that uses eval (see boot2docker/boot2docker#786), many unofficial boot2docker articles/guides still use the old form.

To increase awareness of the corrected version, it's now output at the end of |boot2docker up|.

Fixes #369.