### PR TITLE
Give the user more feedback upon a successful |boot2docker init|

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -66,6 +66,8 @@ func cmdInit() error {
 	if err != nil {
 		return fmt.Errorf("Failed to initialize machine %q: %s", B2D.VM, err)
 	}
+	fmt.Printf("Initialization of virtual machine %q complete.\n", B2D.VM)
+	fmt.Printf("Use `boot2docker up` to start it.\n")
 	return nil
 }
 


### PR DESCRIPTION
Previously there was zero output to the console if init completed successfully, which gave the impression that nothing occurred. Now we explain that the VM has been initialized, as well as how to start it.