### PR TITLE
Add VirtualBox 5 support

### DIFF
--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -658,7 +658,7 @@ func (m *Machine) Modify() error {
 		"--cpuhotplug", m.Flag.Get(F_cpuhotplug),
 		"--pae", m.Flag.Get(F_pae),
 		"--longmode", m.Flag.Get(F_longmode),
-		"--synthcpu", m.Flag.Get(F_synthcpu),
+		//"--synthcpu", m.Flag.Get(F_synthcpu),
 		"--hpet", m.Flag.Get(F_hpet),
 		"--hwvirtex", m.Flag.Get(F_hwvirtex),
 		"--triplefaultreset", m.Flag.Get(F_triplefaultreset),

--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -690,13 +690,13 @@ func (m *Machine) Modify() error {
 
 // AddNATPF adds a NAT port forarding rule to the n-th NIC with the given name.
 func (m *Machine) AddNATPF(n int, name string, rule driver.PFRule) error {
-	return vbm("controlvm", m.Name, fmt.Sprintf("natpf%d", n),
+	return vbm("modifyvm", m.Name, fmt.Sprintf("--natpf%d", n),
 		fmt.Sprintf("%s,%s", name, rule.Format()))
 }
 
 // DelNATPF deletes the NAT port forwarding rule with the given name from the n-th NIC.
 func (m *Machine) DelNATPF(n int, name string) error {
-	return vbm("controlvm", m.Name, fmt.Sprintf("natpf%d", n), "delete", name)
+	return vbm("modifyvm", m.Name, fmt.Sprintf("--natpf%d", n), "delete", name)
 }
 
 // SetNIC set the n-th NIC.

--- a/virtualbox/vbm.go
+++ b/virtualbox/vbm.go
@@ -3,6 +3,7 @@ package virtualbox
 import (
 	"bytes"
 	"errors"
+    "fmt"
 	"io"
 	"log"
 	"os"
@@ -99,6 +100,11 @@ func getHostOnlyNetworkInterface(mc *driver.MachineConfig) (string, error) {
 
 	for _, n := range nets {
 		if dhcp, ok := dhcps[n.NetworkName]; ok {
+            fmt.Printf("IPv4 / DHCP IP: %s == %s\n", dhcp.IPv4.IP, mc.DHCPIP)
+            fmt.Printf("IPv4 netmask: %s == %s\n", dhcp.IPv4.Mask, mc.NetMask)
+            fmt.Printf("DHCP lower bound: %s == %s\n", dhcp.LowerIP, mc.LowerIP)
+            fmt.Printf("DHCP upper bound: %s == %s\n", dhcp.UpperIP, mc.UpperIP)
+            fmt.Printf("DHCP enabled: %s == %s\n", dhcp.Enabled, mc.DHCPEnabled)
 			if dhcp.IPv4.IP.Equal(mc.DHCPIP) &&
 				dhcp.IPv4.Mask.String() == mc.NetMask.String() &&
 				dhcp.LowerIP.Equal(mc.LowerIP) &&


### PR DESCRIPTION
Some improvements to make boot2docker more compatible with VirtualBox 5.

There's still some issues, e.g. that you have to create the exact expected host-only network yourself to make boot2docker-cli pick it up without issues.
But at least this allowed me to bootstrap a boot2docker VM on Windows 10 with VirtualBox 5 (VBox4 doesn't work very well on Windows 10, specifically no host-only networks).

I don't think this a PR ready for merging right away. I've never wrote any go before and didn't set up a proper dev environment either. I just did the minimum steps to get a boot2docker VM up and running. But I figured I might still submit this, maybe there's something useful for you in here.

PS: I know you consider boot2docker-cli deprecated, but docker-machine has the same issues with VirtualBox 5 and its dev environment requires to have docker already running, which was a hen and egg problem for me.