### PR TITLE
Fix issues related to upgrading to Virtualbox 5

### DIFF
--- a/virtualbox/machine.go
+++ b/virtualbox/machine.go
@@ -28,7 +28,6 @@ const (
 	F_cpuhotplug
 	F_pae
 	F_longmode
-	F_synthcpu
 	F_hpet
 	F_hwvirtex
 	F_triplefaultreset
@@ -658,7 +657,6 @@ func (m *Machine) Modify() error {
 		"--cpuhotplug", m.Flag.Get(F_cpuhotplug),
 		"--pae", m.Flag.Get(F_pae),
 		"--longmode", m.Flag.Get(F_longmode),
-		"--synthcpu", m.Flag.Get(F_synthcpu),
 		"--hpet", m.Flag.Get(F_hpet),
 		"--hwvirtex", m.Flag.Get(F_hwvirtex),
 		"--triplefaultreset", m.Flag.Get(F_triplefaultreset),
@@ -690,7 +688,7 @@ func (m *Machine) Modify() error {
 
 // AddNATPF adds a NAT port forarding rule to the n-th NIC with the given name.
 func (m *Machine) AddNATPF(n int, name string, rule driver.PFRule) error {
-	return vbm("controlvm", m.Name, fmt.Sprintf("natpf%d", n),
+	return vbm("modifyvm", m.Name, fmt.Sprintf("--natpf%d", n),
 		fmt.Sprintf("%s,%s", name, rule.Format()))
 }
 


### PR DESCRIPTION
cc @tianon 

This seems to fix the issues seen related to using boot2docker-cli with Virtualbox 5, the latest release.

I have tested this patch in the following situations and creating, starting/stopping, day-to-day Docker operations etc. seem to be working normally with the 1.7.1rc3 ISO provided at https://github.com/tianon/boot2docker:

1. On OSX, with Virtualbox 5
2. On Debian (Jessie) Linux, using Virtualbox 4.3.18
3. On Windows, using Virtualbox 4.* (not sure which actually), and then again with Virtualbox 5

Cheers to @hheimbuerger for taking the initiative on a similar patch, I essentially consider this a carrying of his original patch.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>

Closes https://github.com/boot2docker/boot2docker-cli/pull/373
Fixes https://github.com/boot2docker/boot2docker-cli/issues/374
Fixes https://github.com/boot2docker/boot2docker/issues/979