### PR TITLE
Deprecate boot2docker-cli officially

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-# Pending Deprecation
+# Deprecated
 
-This project is officially in bug fixing/maintenance mode in favor of all
-concerted effort going towards [Docker
-Machine](https://github.com/docker/machine) instead.  Merging of complex
-features will require some pretty strong convincing as to why they should exist
-here, and not instead be proposed for Docker Machine.
+This project is officially deprecated in favor of [Docker Machine](https://docs.docker.com/machine/).  The code and documentation here only exist as a reference for users who have not yet switched over (but please do soon).
 
 # boot2docker command line management tool
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Deprecated
 
-This project is officially deprecated in favor of [Docker Machine](https://docs.docker.com/machine/).  The code and documentation here only exist as a reference for users who have not yet switched over (but please do soon).
+This project is officially deprecated in favor of [Docker
+Machine](https://docs.docker.com/machine/).  The code and documentation here
+only exist as a reference for users who have not yet switched over (but please
+do soon).  The recommended way to install Machine is with the [Docker
+Toolbox](https://docker.com/toolbox).
 
 # boot2docker command line management tool
 

--- a/main.go
+++ b/main.go
@@ -2,14 +2,25 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
-	"path/filepath"
 )
 
 // The following vars will be injected during the build process.
 var (
 	Version string
 	GitSHA  string
+)
+
+const (
+	hardcodedWarning = `
+        WARNING: The 'boot2docker' command line interface is being officially deprecated.
+	Users are expected to switch to Docker Machine (https://docs.docker.com/machine/) instead ASAP.
+	The Docker Toolbox is the recommended way to install it: https://docker.com/toolbox/
+
+`
+	warningURL = "https://raw.githubusercontent.com/boot2docker/boot2docker-cli/master/DEPRECATION_WARNING"
 )
 
 type unknownCommandError struct {
@@ -21,8 +32,6 @@ func (e unknownCommandError) Error() string {
 }
 
 func main() {
-	fmt.Fprintf(os.Stderr, "\n  WARNING: the %q command is officially deprecated.\n    Please switch to Docker Machine (https://docs.docker.com/machine/)\n    as soon as possible.\n\n", filepath.Base(os.Args[0]))
-
 	// os.Exit will terminate the program at the place of call without running
 	// any deferred cleanup statements. It might cause unintended effects. To
 	// be safe, we wrap the program in run() and only os.Exit() outside the
@@ -51,8 +60,10 @@ func run() error {
 	case "config", "cfg":
 		return cmdConfig()
 	case "init":
+		printDeprecationWarning()
 		return cmdInit()
 	case "up", "start", "boot", "resume":
+		printDeprecationWarning()
 		return cmdUp()
 	case "save", "suspend":
 		return cmdSave()
@@ -90,4 +101,28 @@ func run() error {
 	default:
 		return unknownCommandError{cmd: cmd}
 	}
+}
+
+func printDeprecationWarning() {
+	var (
+		warning string
+	)
+
+	// Try to get the warning from the Github raw URL.  If there's any
+	// failure along the way, e.g. network, just fall back to the default
+	// warning hardcoded in the source.
+	resp, err := http.Get(warningURL)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		warning = hardcodedWarning
+	} else {
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			warning = hardcodedWarning
+		} else {
+			warning = string(body)
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, warning)
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // The following vars will be injected during the build process.
@@ -20,6 +21,8 @@ func (e unknownCommandError) Error() string {
 }
 
 func main() {
+	fmt.Fprintf(os.Stderr, "\n  WARNING: the %q command is officially deprecated.\n    Please switch to Docker Machine (https://docs.docker.com/machine/)\n    as soon as possible.\n\n", filepath.Base(os.Args[0]))
+
 	// os.Exit will terminate the program at the place of call without running
 	// any deferred cleanup statements. It might cause unintended effects. To
 	// be safe, we wrap the program in run() and only os.Exit() outside the


### PR DESCRIPTION
This is a WIP and not ready for merge.  **DO NOT MERGE YET**.  This is being opened so we can discuss how to orchestrate and communicate the official deprecation properly, and how we'll manage the release of 1.8 to make sure users have a way to continue using this old code if they absolutely need to while still encouraging them very strongly to move off of it ASAP.

cc @ehazlett @nathanleclaire