### PR TITLE
util: add missing newline at end of debug message

### DIFF
--- a/util.go
+++ b/util.go
@@ -31,7 +31,7 @@ func read(addr string, n int, wait time.Duration) error {
 	var lastErr error
 	for i := 0; i < n; i++ {
 		if B2D.Verbose {
-			fmt.Printf("Connecting to tcp://%v (attempt #%d)", addr, i)
+			fmt.Printf("Connecting to tcp://%v (attempt #%d)\n", addr, i)
 		}
 		conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
 		if err != nil {


### PR DESCRIPTION
Without this, the output looks like:

```
Waiting for VM and Docker daemon to start...
.Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0).Connecting to tcp://localhost:2022 (attempt #0)VM Host-only IP address:
```