### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -1,4 +1,4 @@
-##ToDos to replace the shell script:
+## ToDos to replace the shell script:
 
 ### Configuration
 - [X] modify standard values with enviroment variables


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
